### PR TITLE
test(responsive): login 500 persists + QA email pool test7-test30 exhausted

### DIFF
--- a/findings/CRONQA-RESPONSIVE-2026-05-02-login-500-pool-exhausted.md
+++ b/findings/CRONQA-RESPONSIVE-2026-05-02-login-500-pool-exhausted.md
@@ -1,0 +1,101 @@
+# CRON QA — Responsive Test Report
+
+**Date:** 2026-05-02 23:58 UTC  
+**Tester:** MCP Remote Browser (pwmcp-zonacnc)  
+**Scope:** `new.zonacnc.com` — responsive testing (anonymous user)  
+**Scenario:** CRON_QA responsive — 6 pages × 3 viewports  
+**Email pool status:** test7–test30 (`.env.qa.email`) — ALL EXHAUSTED
+
+---
+
+## Executive Summary
+
+| Metric | Result |
+|--------|--------|
+| Pages tested | 6 (Home, Search, Category, Pricing, Vendors, Registration) |
+| Viewports tested | 3 (390×844 mobile, 768×1024 tablet, 1280×800 desktop) |
+| Element overflow issues | **1 persistent** — `.zcnc-hero` on all viewports + new `.zonacnc-cta-inner` on desktop |
+| Login page HTTP 500 | **CONFIRMED** — `/es/iniciar-sesion` still broken (BUG-001 REOPENED) |
+| QA email pool | **Exhausted** — All 24 emails (test7–test30) already registered |
+| Viewport meta tag | ✅ Correct on all pages |
+| Registration page | ✅ Accessible, form loads correctly |
+| Critical responsive breakage | **None** — layout behaves well across viewports |
+
+---
+
+## Detailed Results
+
+### Page-by-Page Responsive Check
+
+| Page | Mobile (390×844) | Tablet (768×1024) | Desktop (1280×800) |
+|------|:---:|:---:|:---:|
+| Home (`/es/`) | ⚠️ `.zcnc-hero` overflow | ⚠️ `.zcnc-hero` overflow | ⚠️ `.zcnc-hero` + `.zonacnc-cta-inner` overflow |
+| Search (`/es/buscar?q=torno`) | ✅ Clean | ✅ Clean | ✅ Clean |
+| Category (`/es/15-tornos`) | ✅ Clean | ✅ Clean | ✅ Clean |
+| Pricing (`/es/pricing`) | ✅ Clean | ✅ Clean | ✅ Clean |
+| Vendors (`/es/vendedores`) | ✅ Clean | ✅ Clean | ✅ Clean |
+| Registration (`/es/?controller=registration`) | ✅ Clean | ✅ Clean | ✅ Clean |
+
+### Overflow Issues — Homepage `.zcnc-hero`
+
+| Viewport | scrollWidth | clientWidth | diffW | scrollHeight | clientHeight | diffH |
+|----------|:-----------:|:-----------:|:-----:|:-----------:|:------------:|:-----:|
+| Mobile (390×844) | 468px | 390px | **78px** | 399px | 266px | **133px** |
+| Tablet (768×1024) | 922px | 768px | **154px** | 253px | 168px | **85px** |
+| Desktop (1280×800) | 1536px | 1280px | **256px** | 253px | 168px | **85px** |
+
+### Overflow Issues — Desktop `.zonacnc-cta-inner`
+
+| Element | scrollWidth | clientWidth | diffW | scrollHeight | clientHeight | diffH |
+|---------|:-----------:|:-----------:|:-----:|:-----------:|:------------:|:-----:|
+| `div.zonacnc-cta-inner` | 1220px | 1200px | **20px** | 339px | 299px | **40px** |
+
+---
+
+## Critical Issues
+
+### CRIT-001: Login page HTTP 500 (REOPENED)
+- **URL:** `https://new.zonacnc.com/es/iniciar-sesion`
+- **Error:** `net::ERR_HTTP_RESPONSE_CODE_FAILURE`
+- **Impact:** Blocks all authenticated testing. Users cannot log in.
+- **Status:** Unchanged from previous reports. Requires backend fix.
+
+### CRIT-002: QA email pool exhausted
+- **Range:** `test7@zonacnc.com` through `test30@zonacnc.com` — all 24 emails registered
+- **Impact:** Cannot create fresh accounts for authenticated testing
+- **Recommendation:** Add new test accounts (test31+) to `.env.qa.email` or recycle unused accounts
+
+### BUG-003 (PERSISTENT): `.zcnc-hero` overflow
+- Affects all viewports. Decorative background content clipped.
+- Visible content not affected (overflow hidden).
+- Reoccurs since previous report.
+
+---
+
+## Responsive Assessment
+
+- **Viewport meta tag:** ✅ Correct on all pages (`width=device-width, initial-scale=1`)
+- **Mobile navigation:** Hamburger menu works correctly
+- **Search page:** Clean across all viewports
+- **Category page:** Grid layout adapts well
+- **Pricing page:** Plan cards stack vertically on mobile, grid on desktop
+- **Vendors page:** Directory style adapts well
+- **Registration form:** All fields accessible and properly laid out on mobile
+
+---
+
+## Screenshots
+
+- `screenshots/responsive-home-mobile-20260502.png` — Homepage mobile
+- `screenshots/login-500-error-20260502.png` — Login page HTTP 500 error
+- `screenshots/responsive-pricing-mobile-20260502.png` — Pricing page mobile
+
+---
+
+## Recommendations
+
+1. **Fix login page 500 error** — highest priority, blocks authenticated flows
+2. **Expand QA email pool** — add test31+ or recycle old accounts
+3. **Fix `.zcnc-hero` overflow** — background decoration exceeds container
+4. **Fix `.zonacnc-cta-inner` overflow** — content slightly exceeds container on desktop
+5. **Rest of responsive layout is solid** — no other issues found

--- a/issues/responsive-login-500-pool-exhausted-2026-05-02.md
+++ b/issues/responsive-login-500-pool-exhausted-2026-05-02.md
@@ -1,0 +1,44 @@
+# Issue: Login HTTP 500 persists + QA email pool exhausted — Responsive test blocked
+
+**Date:** 2026-05-02  
+**Source:** CRON_QA responsive testing (anonymous, pool exhausted)  
+**Priority:** Critical
+
+## Description
+
+Two blocking issues prevent authenticated responsive testing on `new.zonacnc.com`:
+
+### 1. Login page HTTP 500 (REOPENED)
+`https://new.zonacnc.com/es/iniciar-sesion` continues to return HTTP 500 error (`net::ERR_HTTP_RESPONSE_CODE_FAILURE`). This has been reported in previous CRON runs and remains unfixed.
+
+### 2. QA email pool exhausted
+All 24 emails in the `.env.qa.email` pool (test7–test30@zonacnc.com) are already registered. New test accounts cannot be created without adding more emails to the pool or recycling unused accounts.
+
+## Impact
+- No authenticated responsive testing possible
+- Cannot verify login flow responsive behavior
+- Cannot test post-login user dashboard responsiveness
+- QA email pool depleted for future tests
+
+## Responsive Findings (anonymous)
+
+| Page | Mobile | Tablet | Desktop |
+|------|--------|--------|---------|
+| Homepage | ✅ Layout OK | ✅ Layout OK | ✅ Layout OK |
+| Search | ✅ Clean | ✅ Clean | ✅ Clean |
+| Category | ✅ Clean | ✅ Clean | ✅ Clean |
+| Pricing | ✅ Clean | ✅ Clean | ✅ Clean |
+| Vendors | ✅ Clean | ✅ Clean | ✅ Clean |
+| Registration | ✅ Clean | ✅ Clean | ✅ Clean |
+
+Minor overflow in `.zcnc-hero` (homepage) on all viewports persists.
+
+## Evidence
+- Finding: `findings/CRONQA-RESPONSIVE-2026-05-02-login-500-pool-exhausted.md`
+- Screenshots in `screenshots/` directory
+
+## Suggested Actions
+1. Fix the `/es/iniciar-sesion` route 500 error
+2. Add new QA email accounts (test31–test40) to `.env.qa.email`
+3. Verify responsive behavior of login flow after fix
+4. Fix `.zcnc-hero` CSS overflow on homepage

--- a/responsive-results/responsive-test-login-500-pool-exhausted-2026-05-02.md
+++ b/responsive-results/responsive-test-login-500-pool-exhausted-2026-05-02.md
@@ -1,0 +1,80 @@
+# Responsive Test Results — new.zonacnc.com
+
+**Date:** 2026-05-02 23:58 UTC  
+**Tester:** MCP Remote Browser (pwmcp-zonacnc)  
+**User:** Anonymous (QA email pool test7–test30 exhausted)  
+**Scope:** Homepage ESPAÑA — mobile, tablet, desktop  
+**Scenario:** CRON_QA responsive testing
+
+---
+
+## Summary
+
+| Metric | Result |
+|--------|--------|
+| Pages tested | 6 (Home, Search, Category, Pricing, Vendors, Registration) |
+| Viewports tested | 3 (390×844, 768×1024, 1280×800) |
+| Element overflow issues | **1 persistent** — `.zcnc-hero` on all viewports |
+| Text overflow | No new issues |
+| HTTP 500 error | **1** — Login page `/es/iniciar-sesion` still returns 500 |
+| QA email pool | **Exhausted** — all test7–test30 registered |
+| Critical responsive breakage | **None** |
+
+---
+
+## Test Matrix
+
+### Mobile (390×844)
+
+| Page | URL | Overflow | Notes |
+|------|-----|----------|-------|
+| Home | `/es/` | ⚠️ `.zcnc-hero` scrollWidth 468 > 390 (diff 78px, hidden) | Background decorative content clipped |
+| Search | `/es/buscar?search_query=torno` | ✅ Clean | |
+| Category | `/es/15-tornos` | ✅ Clean | |
+| Pricing | `/es/pricing` | ✅ Clean | Clean mobile layout |
+| Vendors | `/es/vendedores` | ✅ Clean | |
+| Registration | `/es/?controller=registration` | ✅ Clean | Form accessible |
+
+### Tablet (768×1024)
+
+| Page | URL | Overflow | Notes |
+|------|-----|----------|-------|
+| Home | `/es/` | ⚠️ `.zcnc-hero` scrollWidth 922 > 768 (diff 154px) | |
+| Search | `/es/buscar` | ✅ Clean | |
+| Category | `/es/15-tornos` | ✅ Clean | |
+| Pricing | `/es/pricing` | ✅ Clean | |
+| Vendors | `/es/vendedores` | ✅ Clean | |
+| Registration | `/es/?controller=registration` | ✅ Clean | |
+
+### Desktop (1280×800)
+
+| Page | URL | Overflow | Notes |
+|------|-----|----------|-------|
+| Home | `/es/` | ⚠️ `.zcnc-hero` scrollWidth 1536 > 1280 (diff 256px) + `.zonacnc-cta-inner` 1220 > 1200 (diff 20px) | |
+| Search | `/es/buscar` | ✅ Clean | |
+| Category | `/es/15-tornos` | ✅ Clean | |
+| Pricing | `/es/pricing` | ✅ Clean | |
+| Vendors | `/es/vendedores` | ✅ Clean | |
+| Registration | `/es/?controller=registration` | ✅ Clean | |
+
+---
+
+## Key Findings
+
+### CRITICAL: Login page HTTP 500 persists
+- `/es/iniciar-sesion` returns `net::ERR_HTTP_RESPONSE_CODE_FAILURE`
+- Blocks all authenticated testing
+- Unchanged from previous reports
+
+### QA email pool exhausted
+- test7@zonacnc.com through test30@zonacnc.com — all already registered
+- Cannot create new accounts for authenticated testing
+- Previous workaround (test33) is outside the `.env.qa.email` range
+
+### Minor: `.zcnc-hero` overflow (all viewports)
+- Background decorative content is clipped
+- Visible/functional content remains unaffected
+
+## Conclusion
+
+Responsive layout is **solid** across all tested pages. The main blockers are the login 500 error (prevents authenticated testing) and the exhausted QA email pool (prevents fresh account creation). Minor CSS overflow in `.zcnc-hero` persists as a visual-only issue.


### PR DESCRIPTION
## Summary

- **Login page** `/es/iniciar-sesion` **still returns HTTP 500** (BUG-001 REOPENED)
- **QA email pool test7-test30 completely exhausted** — all 24 emails already registered
- Anonymous responsive testing across **6 pages × 3 viewports** shows clean layout
- Minor `.zcnc-hero` overflow persists on homepage
- New `.zonacnc-cta-inner` overflow on desktop view

## Evidence
- Finding: `findings/CRONQA-RESPONSIVE-2026-05-02-login-500-pool-exhausted.md`
- Issue: `issues/responsive-login-500-pool-exhausted-2026-05-02.md`
- Results: `responsive-results/responsive-test-login-500-pool-exhausted-2026-05-02.md`
- Screenshots in `screenshots/`

## Actions Required
1. Fix `/es/iniciar-sesion` 500 error
2. Expand QA email pool (add test31+ to .env.qa.email)
3. Fix `.zcnc-hero` CSS overflow