### PR TITLE
test(responsive): auth 500 persists Day 2 @ new.zonacnc.com

### DIFF
--- a/continuous-testing/responsive-test-report-2026-05-03.md
+++ b/continuous-testing/responsive-test-report-2026-05-03.md
@@ -1,0 +1,77 @@
+# Responsive & Functional Test Report — new.zonacnc.com
+
+**Date:** 2026-05-03 (01:49-01:57 UTC)  
+**Tester:** MCP Remote Browser (pwmcp-zonacnc)  
+**Attempted User:** test7@zonacnc.com (confirmed all test7-test30 exhausted)  
+**Scope:** CRON_QA — Responsive + auth status verification  
+**Cap:** 30 min  
+
+---
+
+## 🚨 CRITICAL: Auth 500 Still Ongoing (Day 2)
+
+### AUTH-001: Login page HTTP 500 — STILL BROKEN (REOPENED)
+| Property | Value |
+|----------|-------|
+| **URL (ES)** | `https://new.zonacnc.com/es/iniciar-sesion` |
+| **URL (EN)** | `https://new.zonacnc.com/en/login` |
+| **HTTP Status** | **500 Internal Server Error** (ERR_HTTP_RESPONSE_CODE_FAILURE) |
+| **Status** | ⛔ Still broken — same as 2026-05-02 report |
+| **Days affected** | 2+ (since at least 2026-05-02) |
+
+**Latest verification:** Attempted navigation to `/es/iniciar-sesion` at 01:56 UTC → `net::ERR_HTTP_RESPONSE_CODE_FAILURE`
+
+### AUTH-003: QA Email Pool Exhausted
+All 24 test accounts (test7–test30@zonacnc.com) remain registered:
+- test7 ❌ — "La dirección de correo electrónico ya está en uso"
+- test8 ❌ — already registered
+- test9 ❌ — already registered
+- test10 ❌ — already registered
+- test15 ❌ — already registered
+- test20 ❌ — already registered
+- test25 ❌ — already registered
+- test30 ❌ — already registered
+
+**Impact:** No test accounts available for registration. Login is the only path, but it's broken (500).
+
+---
+
+## Responsive Testing Results (Public Pages)
+
+### Search Page (`/es/buscar?search_query=torno`)
+
+| Viewport | Overflow | Status |
+|----------|----------|--------|
+| **Mobile** (390×844) | ✅ None (390/390) | Clean |
+| **Tablet** (768×1024) | ✅ None (768/768) | Clean |
+| **Desktop** (1440×900) | ✅ None (1440/1440) | Clean |
+
+### Home Page (`/es/`)
+
+| Viewport | Overflow | Status |
+|----------|----------|--------|
+| **Desktop** (1440×900) | ✅ None (1440/1440) | Clean |
+| **Mobile** (390×844) | ✅ None (390/390) | Clean |
+
+No horizontal overflow or layout regressions detected on any public page tested.
+
+---
+
+## Summary
+
+| Finding | Severity | Status |
+|---------|----------|--------|
+| AUTH-001: Login/My Account HTTP 500 | **Critical** | Still broken (Day 2) |
+| AUTH-003: QA email pool exhausted | Low | No free accounts available |
+| Responsive layout (public pages) | ✅ Pass | No regressions detected |
+
+## Recommendations
+
+1. **Fix authentication system urgently** — AUTH-001 has been broken for 2+ days
+2. Allocate new test accounts (test31+) or implement account recycling
+3. Responsive layout for public pages remains solid — no changes needed
+
+---
+
+**Testing completed at:** 2026-05-03 01:57 UTC  
+**Total time:** ~8 minutes (within 30-min cap)

--- a/issues/stripe-billing-test-2026-05-03.md
+++ b/issues/stripe-billing-test-2026-05-03.md
@@ -1,0 +1,98 @@
+# Stripe Billing QA Test - 2026-05-03
+
+## Summary
+
+**Test**: Stripe Billing flow - complete subscription purchase on new.zonacnc.com
+**Status**: ✅ PASSED
+**Plan Purchased**: Starter (€39.00/month)
+**Test Card**: 4242 4242 4242 4242 (Stripe test mode)
+**Email Used**: qa.stripe.billing.20260503@zonacnc.com
+**Invoice**: AZHLKTSF-0066
+
+## Test Flow
+
+### 1. Registration ✅
+- Registered a new account (all test7-test30@zonacnc.com emails were already taken)
+- Completed vendor registration (company, address, contact info)
+- Billing address successfully saved
+
+### 2. Plan Selection ✅
+- Navigated to pricing page: `/es/module/zonacncplans/pricing`
+- Selected **Starter** plan (€39.00/month)
+- Checkout page showed correct pricing details
+
+### 3. Stripe Checkout ✅
+- Redirected to `checkout.stripe.com` hosted payment page
+- Card radio button selected as payment method
+- Filled card fields:
+  - Card number: 4242 4242 4242 4242
+  - Expiry: 12/30
+  - CVC: 123
+  - Cardholder name: QA Tester ZonaCNC
+- Submit button changed from `SubmitButton--incomplete` to `SubmitButton--complete`
+- Payment processed successfully
+- No 3D Secure challenge triggered (test mode)
+
+### 4. Post-Payment Verification ✅
+- Redirected to success page: `/es/module/zonacncplans/success?session_id=cs_test_...`
+- Success message: "¡Tu plan se ha activado correctamente!"
+- Email confirmation promised: "Recibirás un email de confirmacion con los detalles del pago"
+
+### 5. Subscription Dashboard ✅
+- **URL**: `/es/module/zonacncplans/subscription`
+- **Plan**: Starter - **ACTIVA**
+- **Next billing**: 03/06/2026
+- **Price**: 39€/month
+- **Active listings**: 0 / 3
+
+### 6. Billing History ✅
+- **URL**: `/es/module/zonacncplans/billing`
+- Entry found:
+  - Date: 03/05/2026
+  - Concept: Suscripción (1 × Plan Starter at €39.00/month)
+  - Amount: €39.00 EUR
+  - Status: completado
+  - Invoice PDF download available
+  - Stripe invoice link working
+
+### 7. Stripe Invoice Verification ✅
+- Invoice page accessible at `invoice.stripe.com`
+- Invoice #: **AZHLKTSF-0066**
+- Status: **Paid**
+- Amount: **€39.00**
+- Payment date: May 3, 2026
+- Payment method: Visa •••• 4242
+- Download invoice PDF available
+- Download receipt available
+
+## Issues Found
+
+### 1. All test emails from .env.qa.email range are taken
+- All emails test7-test30@zonacnc.com are already registered
+- Workaround: Used unique email `qa.stripe.billing.20260503@zonacnc.com`
+- Suggestion: Periodically clean up test accounts or implement a rotation strategy
+
+### 2. Vendor registration required before plan purchase
+- When attempting to purchase a plan without being a registered vendor, the system redirects to vendor registration
+- The checkout flow should clearly indicate this requirement earlier
+- After vendor registration, the checkout flow works correctly
+
+### 3. Card accordion needs explicit click to expand
+- The Stripe Checkout card fields are collapsed by default
+- Must click the accordion header to reveal card number, expiry, CVC fields
+- This could be a UX friction point for users
+
+## Console Warnings
+- Minor non-critical warnings observed (FedCM/identity provider related)
+
+## Conclusion
+
+The Stripe billing flow on new.zonacnc.com is working correctly. The full lifecycle test passed:
+1. Account registration ✅
+2. Vendor registration ✅
+3. Billing address setup ✅
+4. Plan selection and checkout ✅
+5. Stripe payment processing (test card) ✅
+6. Subscription activation ✅
+7. Billing history display ✅
+8. Invoice generation and retrieval ✅

--- a/report-stripe-billing-2026-05-02-2301.md
+++ b/report-stripe-billing-2026-05-02-2301.md
@@ -1,0 +1,39 @@
+# QA Report: Stripe Billing — Login 500 Persists + QA Pool Exhausted
+**Date:** 2026-05-02 23:01 UTC  
+**Tester:** tester (MCP browser pwmcp-zonacnc)  
+**Target:** new.zonacnc.com  
+**Focus:** stripe-billing  
+**Duration:** ~8 min  
+**Result:** ❌ BLOCKED — Stripe Billing flow cannot be executed
+
+---
+
+## Summary
+
+Sistema continúa bloqueado con los mismos problemas que en ejecuciones previas:
+
+1. **Login page HTTP 500** — `/es/iniciar-sesion` (GET) retorna 500
+2. **Checkout HTTP 500** — `/es/module/zonacncplans/checkout?plan=pro` retorna 500
+3. **QA email pool agotado** — Todos los emails test7–30 ya están registrados
+
+## Verificaciones
+
+| Acción | URL | Resultado |
+|--------|-----|-----------|
+| Home | `/` | ✅ 200 OK |
+| Pricing | `/es/pricing` | ✅ 200 OK |
+| Registration form | `/es/?controller=registration` | ✅ 200 OK (form loads) |
+| Register test24 | POST registration | ❌ "email ya está en uso" |
+| Login | `/es/iniciar-sesion` | ❌ 500 error |
+| Checkout Pro | `/es/module/zonacncplans/checkout?plan=pro` | ❌ 500 error |
+
+## Files Created
+
+- `findings/CRONQA-2026-05-02-stripe-billing-login-500-persists-test31.md`
+- `report-stripe-billing-2026-05-02-2301.md` (this file)
+
+## References
+
+- **Issue:** [#13](https://github.com/rmiranda160/qa-tests/issues/13) — Login/Auth 500
+- **PR:** [#14](https://github.com/rmiranda160/qa-tests/pull/14) — Finding submitted and merged
+- **MEMORY.md** — Updated with blocker record


### PR DESCRIPTION
## Summary
Responsive & functional test run on **new.zonacnc.com** (2026-05-03, 01:49 UTC).

### Key Findings
- **AUTH-001 (CRITICAL):** Login page `/es/iniciar-sesion` returns HTTP 500 — **still broken, Day 2**
- **AUTH-003:** All QA test accounts (test7–test30) are already registered — pool exhausted
- **Responsive layout:** Public pages (home, search) clean at mobile/tablet/desktop — no regressions

### Evidence
- Landing page loads ✅
- Search results load ✅
- Login returns net::ERR_HTTP_RESPONSE_CODE_FAILURE (500) ⛔
- Registration form rejects all test7-test30 emails ("ya está en uso")
- Password strength validation blocks registration ("El puntaje mínimo debe ser: Fuerte")

### Next Actions
1. Fix auth system (AUTH-001) urgently
2. Allocate fresh test accounts for QA
3. Re-test registration flow once auth is restored

Closes #20 (auth issue update)