### PR TITLE
test(stripe-billing): QA email pool exhausted + login 500 persists (Day 4) @ new.zonacnc.com

### DIFF
--- a/findings/CRONQA-2026-05-03-stripe-billing-pool-exhausted-day-4.md
+++ b/findings/CRONQA-2026-05-03-stripe-billing-pool-exhausted-day-4.md
@@ -1,0 +1,34 @@
+# CRONQA Finding: Stripe Billing BLOCKED — Pool Exhausted Day 4 + Login 500 Persists
+
+**Date:** 2026-05-03 03:27 UTC  
+**Tester:** tester (MCP remote pwmcp-zonacnc)  
+**Target:** new.zonacnc.com  
+**Focus:** stripe-billing  
+**Duration:** ~5 min  
+**Escenario:** 1/1 — ❌ BLOCKED  
+
+## Blockers
+
+### 1. Login page HTTP 500 (Día 4)
+- URL: `https://new.zonacnc.com/es/iniciar-sesion`
+- Error: `net::ERR_HTTP_RESPONSE_CODE_FAILURE`
+- Persistente desde al menos 2026-04-30
+- Sin login no se puede autenticar cuentas existentes para probar Stripe Billing
+
+### 2. QA email pool test7-test30 completamente exhausto (Día 4)
+- `.env.qa.email` contiene 24 emails: test7–test30@zonacnc.com
+- Verificado: test7@zonacnc.com → "La dirección de correo electrónico ya está en uso"
+- Todos confirmados como TAKEN en ejecuciones anteriores
+- Sin email disponible del pool no se puede registrar nueva cuenta
+
+## Impacto
+Sin email disponible del pool y sin login funcional, no es posible:
+- ✅ Registrar nueva cuenta
+- ❌ Iniciar sesión en cuentas existentes
+- ❌ Navegar a Pricing y seleccionar plan
+- ❌ Probar flujo completo de Stripe Checkout
+
+## Recomendación
+1. **Refrescar pool QA**: Añadir nuevos emails test31+@zonacnc.com al `.env.qa.email`
+2. **Reparar login**: Arreglar HTTP 500 en `/es/iniciar-sesion`
+3. Alternativamente: permitir test con emails fuera del pool si hay IMAP configurado

--- a/issues/stripe-billing-pool-exhausted-day4-2026-05-03.md
+++ b/issues/stripe-billing-pool-exhausted-day4-2026-05-03.md
@@ -1,0 +1,24 @@
+# Issue #28: Stripe Billing BLOCKED — QA email pool exhausto Día 4 + Login 500 persiste
+
+**Asignado:** QA Tester  
+**Prioridad:** Alta  
+**Target:** new.zonacnc.com  
+**Labels:** stripe-billing, blocked, login-500, pool-exhausted
+
+## Bloqueantes
+
+### 1. Login HTTP 500 (Día 4 consecutivo)
+`/es/iniciar-sesion` retorna error 500. Verificado a las 03:27 UTC:
+```
+net::ERR_HTTP_RESPONSE_CODE_FAILURE at https://new.zonacnc.com/es/iniciar-sesion
+```
+
+### 2. Pool QA emails exhausto
+Los 24 emails del `.env.qa.email` (test7–test30@zonacnc.com) están todos registrados:
+```
+test7@zonacnc.com → "La dirección de correo electrónico ya está en uso"
+```
+
+## Pasos para resolver
+1. Añadir nuevos emails al `.env.qa.email` (test31+@zonacnc.com) con sus credenciales IMAP
+2. Reparar el endpoint `/es/iniciar-sesion` que devuelve HTTP 500


### PR DESCRIPTION
## QA Report: Stripe Billing — Day 4 Blocked

### Status: ❌ BLOCKED

**Escenario:** 1/1 — No ejecutable

### Bloqueantes

1. **Login HTTP 500 (Día 4)** — `/es/iniciar-sesion` retorna error 500
2. **Pool QA emails exhausto** — Todos los 24 emails test7–test30@zonacnc.com confirmados como TAKEN

### Verificación
- test7@zonacnc.com → "La dirección de correo electrónico ya está en uso"
- Login → net::ERR_HTTP_RESPONSE_CODE_FAILURE

### Issue #28
- issues/stripe-billing-pool-exhausted-day4-2026-05-03.md

**Finding:** findings/CRONQA-2026-05-03-stripe-billing-pool-exhausted-day-4.md

**Requiere:**
1. Refrescar pool QA (test31+@zonacnc.com)
2. Reparar login HTTP 500