### PR TITLE
[CRONQA] Responsive — Site outage HTTP 500 bloquea testing responsive (confirmado 16:57 UTC)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -81,3 +81,19 @@
 | ❌ BLOCKED | `findings/CRONQA-2026-05-03-stripe-billing-pool-exhausted-day5.md` | #33 (comment) | [#34](https://github.com/rmiranda160/qa-tests/pull/34) |
 
 **State:** Login 500 (Día 5), QA pool test7-test30 exhausted (Día 5). Sin cambios.
+
+## Stripe Billing — 2026-05-03 16:54 UTC — Site Outage HTTP 500 (Regresión #2)
+
+| Result | Finding | Issue | PR |
+|--------|---------|-------|----|
+| ❌ BLOCKED | `findings/CRONQA-2026-05-03-stripe-billing-site-outage-v2.md` | [#68](https://github.com/rmiranda160/qa-tests/issues/68) | [#67](https://github.com/rmiranda160/qa-tests/pull/67) (merged) |
+
+**Detail:** Segundo outage en 48h con mismo patrón (HTTP 500 cuerpo vacío todas las rutas). Último éxito 15:19 UTC (~1h 35min antes). Stripe billing completamente bloqueado.
+
+## Responsive — 2026-05-03 16:57 UTC — Site Outage Bloquea Testing Responsive
+
+| Result | Finding | Issue | PR |
+|--------|---------|-------|----|
+| ❌ BLOCKED | `findings/CRONQA-RESPONSIVE-2026-05-03-site-outage-blocks-testing.md` | [#68](https://github.com/rmiranda160/qa-tests/issues/68) (update) | Current branch |
+
+**Detail:** Site outage HTTP 500 persiste desde 16:54 UTC. Responsive testing completamente bloqueado (no se puede acceder a ninguna página para probar layout, viewports, touch targets, ni emails). Último responsive exitoso: 16:19 UTC (verificación completa 6 páginas). Misma causa raíz que stripe-billing outage.

--- a/findings/CRONQA-RESPONSIVE-2026-05-03-site-outage-blocks-testing.md
+++ b/findings/CRONQA-RESPONSIVE-2026-05-03-site-outage-blocks-testing.md
@@ -1,0 +1,72 @@
+# CRON QA: Responsive — Site Outage HTTP 500 Bloquea Testing
+
+**Date:** 2026-05-03 16:57 UTC  
+**Focus:** responsive  
+**Site:** new.zonacnc.com  
+**Agent:** tester (cron: tester-responsive)  
+**Label:** qa-responsive  
+
+---
+
+## Estado: ❌ BLOQUEADO — Site Outage HTTP 500 (todas las rutas)
+
+### Descripción
+El sitio **new.zonacnc.com** está completamente caído. Todas las rutas públicas (home, categorías, pricing, login, contact, etc.) devuelven **HTTP 500 Internal Server Error** con cuerpo vacío (`content-length: 0`). El responsive test para este ciclo **no puede ejecutarse**.
+
+### Timeline del día
+
+| Evento | Hora UTC | Estado |
+|--------|----------|--------|
+| Responsive full verification (6 páginas, 3 viewports, emails) | 16:19 UTC | ✅ PASS |
+| Outage detectado (stripe-billing agent) | 16:54 UTC | ❌ OUTAGE |
+| Confirmación responsive (current cron) | 16:57 UTC | ❌ OUTAGE CONFIRMADO |
+
+### Rutas verificadas (16:57 UTC)
+
+| Ruta | Código | Body |
+|------|--------|------|
+| `https://new.zonacnc.com/` | 500 | vacío |
+| `https://new.zonacnc.com/es/` | 500 | vacío |
+| `https://new.zonacnc.com/en/` | 500 | vacío |
+| `https://new.zonacnc.com/es/25-prensas` (categoría) | 500 | vacío |
+| `https://new.zonacnc.com/es/contactenos` | 500 | vacío |
+| `https://new.zonacnc.com/es/content/1-about-us` | 500 | vacío |
+| `https://new.zonacnc.com/es/content/2-legal-notice` | 500 | vacío |
+| `https://new.zonacnc.com/es/module/ps_accounts/onboarding` | 500 | vacío |
+| `https://new.zonacnc.com/es/pricing` | 500 | vacío |
+| `https://new.zonacnc.com/robots.txt` | **200** ✅ | estático nginx |
+
+### Diagnóstico técnico
+
+```
+Server: nginx
+PHP: 8.3.30
+Content-Length: 0 (todas las rutas)
+Patrón: idéntico al outage del 2026-05-02 (~14:38 UTC)
+```
+
+- **nginx** operativo (robots.txt 200)
+- **PHP-FPM** activo (genera sesión PrestaShop)
+- **Aplicación PrestaShop crashea** sin generar output → probable PHP fatal error
+- **Segundo outage recurrente** en 48h con mismo patrón
+
+### Impacto en Responsive Testing
+- ❌ No se puede probar layout responsive en ninguna página
+- ❌ No se pueden verificar viewports, overflow, touch targets
+- ❌ No se pueden verificar plantillas de email
+- ❌ MCP browser y Playwright remote fallan (sitio caído + browser unreachable)
+- 🔄 Responsive test bloqueado hasta resolución del outage
+
+### Diferencia con última prueba exitosa
+La última prueba responsive exitosa fue a las **16:19 UTC** (hace ~38 min). En ese momento:
+- Homepage, Tornos, Pricing, Vendedores, Login, Registration funcionaban correctamente
+- 3 viewports sin overflow ni errores
+- Emails verificados vía IMAP (test30@zonacnc.com)
+- Welcome, password reset, password updated templates OK en español
+
+### Referencias
+- PR #67 (merged): Site outage HTTP 500 (stripe-billing)
+- Issue #68: [CRITICAL] new.zonacnc.com — HTTP 500 Site Outage (3 May 2026)
+- Finding stripe-billing: `CRONQA-2026-05-03-stripe-billing-site-outage-v2.md`
+- Responsive full verification (pre-outage): `CRONQA-RESPONSIVE-2026-05-03-full-verification.md`
+- Mismo patrón que outage May 2: `responsive-500-outage-2026-05-02.md`

--- a/skills/web-tester/responsive-results/CRON-2026-05-03-1657-summary.md
+++ b/skills/web-tester/responsive-results/CRON-2026-05-03-1657-summary.md
@@ -1,0 +1,65 @@
+# CRON QA — Responsive "Site Outage" (2026-05-03 16:57)
+
+**Agent:** tester  
+**Focus:** responsive  
+**URL:** https://new.zonacnc.com/es/ (y 9 rutas adicionales)  
+**Page:** All public pages — **SITE OUTAGE**  
+**Method:** curl HTTP status check (MCP browser + Playwright remote unreachable)  
+
+---
+
+## Verdict: ❌ BLOCKED — Full Site Outage HTTP 500
+
+## Test Results
+
+| Ruta | Esperado | Real | Estado |
+|------|----------|------|--------|
+| `/` | 200 | 500 | ❌ |
+| `/es/` | 200 | 500 | ❌ |
+| `/en/` | 200 | 500 | ❌ |
+| `/es/25-prensas` | 200 | 500 | ❌ |
+| `/es/contactenos` | 200 | 500 | ❌ |
+| `/es/content/1-about-us` | 200 | 500 | ❌ |
+| `/es/content/2-legal-notice` | 200 | 500 | ❌ |
+| `/es/module/ps_accounts/onboarding` | 200 | 500 | ❌ |
+| `/es/pricing` | 200 | 500 | ❌ |
+| `/robots.txt` | 200 | 200 | ✅ |
+
+## Detalles del Outage
+
+- **Todas las rutas dinámicas HTTP 500**
+- body: vacío (content-length: 0)
+- PHP/8.3.30 activo (sesión PrestaShop generada)
+- Aplicación PrestaShop crashea sin output
+- **Patrón idéntico** al outage del 2026-05-02
+- **Segundo outage recurrente en 48h**
+
+## Última prueba responsive exitosa
+
+| Detalle | Valor |
+|---------|-------|
+| Hora | 16:19 UTC (hoy, ~38 min antes) |
+| Páginas verificadas | 6 (home, tornos, pricing, vendedores, login, registration) |
+| 3 viewports | ✅ Sin overflow, sin errores |
+| Emails IMAP | ✅ Welcome, password reset, password updated |
+
+## Impacto
+
+| Aspecto | Estado |
+|---------|--------|
+| Layout responsive | ❌ No testeable |
+| Touch targets WCAG | ❌ No testeable |
+| Email templates | ❌ No verificable |
+| Navigation responsive | ❌ No testeable |
+| Horizontal overflow | ❌ No testeable |
+
+---
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total checks | 10 |
+| Pass | 1 (robots.txt) |
+| Fail | 9 (HTTP 500) |
+| **Blocking issue** | **Site outage — responsive test cannot execute** |


### PR DESCRIPTION
## Resumen

El sitio **new.zonacnc.com** sigue completamente caído (HTTP 500 en todas las rutas). El segundo outage en 48h con patrón idéntico.

## Este PR añade

- **Finding responsive:** `findings/CRONQA-RESPONSIVE-2026-05-03-site-outage-blocks-testing.md`
- **Summary responsive:** `skills/web-tester/responsive-results/CRON-2026-05-03-1657-summary.md`
- **MEMORY.md update** con entrada responsive para este outage

## Timeline responsive del día

| Evento | Hora UTC |
|--------|----------|
| ✅ Responsive full verification (6 páginas, 3 viewports, emails) | 16:19 UTC |
| ❌ Outage detectado | 16:54 UTC |
| ❌ Confirmación responsive | 16:57 UTC |

## Impacto en responsive

- No se puede probar layout responsive en ninguna página
- No se pueden verificar viewports, overflow, touch targets
- No se pueden verificar plantillas de email
- MCP browser + Playwright remote unreachable

## Related

- Issue: #68 (CRITICAL site outage)
- Finding stripe-billing: `CRONQA-2026-05-03-stripe-billing-site-outage-v2.md`
- Mismo patrón que outage May 2