### PR TITLE
QA(stripe-billing): Email template i18n audit — 8 findings (5 P0, 3 P1)

### DIFF
--- a/branch-marker
+++ b/branch-marker
@@ -1,1 +1,1 @@
-cronqa/responsive-2026-05-06T0550
+cronqa/stripe-billing-2026-05-06T1004

--- a/findings-stripe-billing.md
+++ b/findings-stripe-billing.md
@@ -1,140 +1,212 @@
-# Findings: Stripe Billing QA — 2026-05-06
-
-**Test account:** test25@zonacnc.com (Customer ID 6652, "Test TwentyFive", Plan Starter mensual)
-**Previous report:** test9@zonacnc.com (2026-05-05)
-
----
-
-## Finding 1 — HIGH: Missing space in password reset email subject (CONFIRMED REGRESSION)
-
-**Location:** Email template for password recovery confirmation  
-**Evidence:** Subject line of emails #14, #8, #6 read:
-
-```
-[zonacnc.com] Confirmación decontraseña
-```
-
-Missing space between "de" and "contraseña". The correct subject should be:
-
-```
-[zonacnc.com] Confirmación de contraseña
-```
-
-**Expected:** "Confirmación de contraseña"  
-**Actual:** "Confirmación decontraseña"  
-**Impact:** Unprofessional appearance in password recovery emails. Users may perceive reduced credibility.  
-**Previously reported:** Yes (finding #5 from 2026-05-04 on test8, 2026-05-05 on test9)  
-**Confirmed on:** test25@zonacnc.com, all password reset emails since account creation
+# QA Report — Stripe Billing · new.zonacnc.com
+**Date:** 2026-05-06 10:42–11:10 UTC  
+**Focus Area:** stripe-billing (email templates, translations, pricing consistency)  
+**Scenario:** Multi-account email template review + pricing page verification  
+**Accounts reviewed:** test21, test22, test16, test10, test26, test8, test18  
+**Site:** https://new.zonacnc.com (logged in as test3@zonacnc.com for UI)
 
 ---
 
-## Finding 2 — MEDIUM: Misleading announcement count in Starter welcome email
-
-**Location:** Email template `¡Bienvenido a Starter! Tu suscripción está activa` (email #11)
-**Evidence:** The welcome email body states:
-
-```
-Detalles:
-- Plan: Starter
-- Periodo: monthly
-- Cuota mensual: 39,00 €
-- Anuncios incluidos: 1
-- Próxima renovación: 05/06/2026
-```
-
-However, the Starter plan on the site clearly shows **3 anuncios** included (0 / 3 on the subscription dashboard). The plan change page also confirms Starter = 3 anuncios.
-
-**Expected:** "Anuncios incluidos: 3"  
-**Actual:** "Anuncios incluidos: 1"  
-**Impact:** Users may believe they only have 1 listing slot instead of 3, reducing their use of the platform or triggering unnecessary support contacts.  
-**Previously reported:** No (new finding)
+## Scope
+Review billing email templates, translations, plan data consistency, and password recovery flow across the test7–test30 account pool. Compare pricing page data against email template values.
 
 ---
 
-## Finding 3 — LOW: Subscription page missing proper page title
+## Findings Summary
 
-**Location:** /es/suscripcion page  
-**Evidence:** The page `<title>` tag renders as just:
-
-```
-zonacnc.com
-```
-
-While other account pages have descriptive titles:
-- /es/facturacion → "Facturas y pagos · ZonaCNC"
-- /es/cambiar-plan → "Cambiar plan — ZonaCNC"
-
-**Expected:** "Mi suscripción · ZonaCNC" or similar descriptive title  
-**Actual:** "zonacnc.com"  
-**Impact:** SEO and accessibility degradation. Users with many open tabs cannot identify this page.  
-**Previously reported:** No (new finding)
+| # | Severity | Component | Description | Cross-Account |
+|---|----------|-----------|-------------|:---:|
+| 1 | **P0** | Email·Template | Starter welcome: "Anuncios incluidos: 1" (pricing shows 3) | ✅ test21, test26 |
+| 2 | **P0** | Email·I18N | Cancellation email: English body + "Your tu plan plan" mix | ✅ test22, test26 |
+| 3 | **P0** | Email·I18N | Onboarding email: English body + `{myads_url}` unresolved | ✅ test10, test26 |
+| 4 | **P0** | Email·Delivery | Password recovery emails NOT delivered to test18, test22 | ✅ test18, test22 |
+| 5 | **P0** | Email·I18N | Invoice email: English body for Spanish account | ✅ test10 |
+| 6 | **P1** | Email·I18N | Onboarding HTML `<title>` = "Get started on ZonaCNC" (ES subj) | ✅ test10, test26 |
+| 7 | **P1** | UI·Pricing | Free plan shows "1 anuncio activo" (previous reports showed 3) | test3 |
+| 8 | **P1** | Email·Delivery | Password recovery tokens expire within ~1h | ✅ test21 |
+| 9 | — | Info | Pricing page well structured, all 5 plans present, annual toggle works | — |
+| 10 | — | Info | Subscription page (mi cuenta) functional, correct sidebar items | test3 |
 
 ---
 
-## Finding 4 — LOW: Missing accents in footer legal links (ES translation)
+## Detailed Findings
 
-**Location:** Footer navigation on all pages (ES locale)  
-**Evidence:** Two legal links lack proper accent marks:
+### F1 [P0] — Starter Welcome: Wrong Ad Count (REGRESSION, cross-account)
+**Evidence:** test21 #8, test26 #15
 
 ```
-Politica de privacidad   → should be "Política de privacidad"
-Politica de cookies       → should be "Política de cookies"
+Subject: ¡Bienvenido a Starter! Tu suscripción está activa
+Body:  - Plan: Starter
+       - Anuncios incluidos: 1
+       - Cuota mensual: 39,00 €
 ```
 
-**Expected:** "Política de privacidad" and "Política de cookies"  
-**Actual:** "Politica de privacidad" and "Politica de cookies"  
-**Impact:** Minor translation quality issue affecting professional appearance across all pages.  
-**Previously reported:** No (new finding)
+Pricing page (`/es/pricing`) clearly states Starter = **3 anuncios activos**. The email template says **1**. This creates customer confusion and potential legal risk (misrepresentation of plan benefits).
+
+**Impact:** Customers believe they paid for only 1 ad; may complain or cancel.
+**Root cause:** Email template `{active_products}` variable mapped to wrong value or hardcoded.
 
 ---
 
-## Finding 5 — INFO: Console JavaScript errors on all account pages
-
-**Location:** All account pages (/es/suscripcion, /es/facturacion, /es/cambiar-plan)  
-**Evidence:** Each page generates 1 JavaScript console error:
+### F2 [P0] — Cancellation Email: English Body + ES/EN Language Mix (REGRESSION, cross-account)
+**Evidence:** test22 #11, test26 #10
 
 ```
-Unexpected token '&'
+Subject: Tu suscripción se ha cancelado  (SPANISH ✓)
+Body:  Hello QA Tester,                  (ENGLISH ✗)
+       Your tu plan plan has been canceled.  (BROKEN MIX ✗)
 ```
 
-This appears to be a JavaScript parsing error, likely from inline script blocks containing unescaped HTML entities.
+- Subject is correct Spanish, but body is entirely English
+- "Your tu plan plan" = nonsensical mix: English "your" + Spanish "tu" + duplicate "plan"
+- Full body in English: "If you would like to re-subscribe...", "If you have any questions..."
+- Both test22 (QA Tester) and test26 (QA Tester DE) are Spanish-language accounts
 
-**Impact:** Minor — no visible user-facing breakage observed, but may indicate fragile JS handling.  
-**Previously reported:** No (new finding)
+**Impact:** Unprofessional, confusing; non-English speakers cannot understand cancellation details.
+**Previously reported:** Yes (2026-05-06 v2 F3). Still present.
 
 ---
 
-## Items Verified — No Issues Found
+### F3 [P0] — Onboarding Email: English Body + Unresolved Placeholder (REGRESSION, cross-account)
+**Evidence:** test10 #14, test26 #8
 
-The following were checked and found to be working correctly:
+```
+Subject: Empieza con buen pie en ZonaCNC: 3 pasos en 10 minutos  (SPANISH ✓)
+HTML <title>: Get started on ZonaCNC                              (ENGLISH ✗)
+Body:  Hello Test,                                                (ENGLISH ✗)
+       Welcome as a seller on ZonaCNC!
+       Start selling:
+       {myads_url}                                                (BROKEN ✗)
+```
 
-| Component | Result |
-|-----------|--------|
-| Password recovery flow (ES) | ✅ Link generated and functional |
-| Password reset confirmation email | ✅ "Su nueva contraseña" email sent correctly |
-| Password reset form | ✅ Both password fields, show/hide toggle working |
-| Login after password reset | ✅ Redirect to Mi Cuenta, success alert shown |
-| Subscription dashboard | ✅ Plan info, next charge date, active listing count displayed |
-| Invoice/billing history | ✅ Date, concept, amount, status, PDF download, Stripe invoice link all functional |
-| Plan change page | ✅ All 5 plans (Free/Starter/Pro/Business/Enterprise) displayed with correct pricing and features |
-| Plan change upgrade/downgrade info | ✅ Clear explanation of prorated charges |
-| 7-day refund policy | ✅ Detailed conditions displayed |
-| Breadcrumb navigation | ✅ Consistent across account pages |
-| Language switcher | ✅ All 10 languages available in header |
-| Sidebar navigation | ✅ All links present and functional |
+- Title and body are fully English despite Spanish account
+- `{myads_url}` placeholder is NOT replaced — shows literal text `{myads_url}`
+- Newer emails (test26 #14) correctly use Spanish template → template selection is inconsistent
+
+**Impact:** Broken UX for new sellers; broken link means they can't start selling.
+**Previously reported:** Yes (2026-05-06 v2 F8). Still present.
 
 ---
 
-## Summary
+### F4 [P0] — Password Recovery Emails Not Delivered (REGRESSION)
+**Evidence:** 
+- Requested password reset for test18@zonacnc.com at 10:50 UTC → no email arrived (inbox still 4 emails, oldest from May 3)
+- Requested password reset for test22@zonacnc.com at 10:53 UTC → no email arrived (inbox still 11 emails, last from May 5)
+- test21 received reset confirmation at 10:45 UTC but the reset token expired within minutes
+- test3 used as workaround for UI review only
 
-| ID | Severity | Description | Previously Reported |
-|----|----------|-------------|---------------------|
-| 1  | HIGH | Missing space in password reset email subject: "decontraseña" | Yes (confirmed regression) |
-| 2  | MEDIUM | Starter welcome email says "1 anuncio" but plan has 3 | **New** |
-| 3  | LOW | /es/suscripcion page title is just "zonacnc.com" | **New** |
-| 4  | LOW | Footer links "Politica" missing accent (→ "Política") | **New** |
-| 5  | INFO | Console JS errors "Unexpected token '&'" on account pages | **New** |
+**Impact:** Cannot log into test7–test30 pool accounts for billing testing; customers locked out.
+**Previously reported:** Yes (2026-05-06 v2 F2). Still present, worsening.
 
-**New findings this run:** #2, #3, #4, #5
-**Regressions confirmed:** #1
-**Previously reported findings NOT tested this run:** add-on variable substitution (Finding #1 from 2026-05-05), invoice "renovación" label (Finding #2 from 2026-05-05) — test25 has no add-ons to verify these.
+---
+
+### F5 [P0] — Invoice Email: English Body for Spanish Account (REGRESSION)
+**Evidence:** test10 #15
+
+```
+Subject: Factura pagada — Tu plan sigue activo     (SPANISH ✓)
+Body:  Hello Test,                                  (ENGLISH ✗)
+       We have charged the renewal of your Starter plan. Your subscription remains
+       active until 06/06/2026.
+       - Amount: 39,00 €
+       - Plan: Starter (monthly)
+       - Next charge: 06/06/2026
+       ...
+       Thank you
+```
+
+- Subject correctly Spanish, but entire body is English
+- Compare with test21 #10: same subject, but body IS Spanish → **template selection is inconsistent**
+
+**Impact:** Non-English-speaking customers cannot understand their billing details.
+
+---
+
+### F6 [P1] — Onboarding HTML `<title>` Tag: English for Spanish Email
+**Evidence:** test10 #14, test26 #8
+- `<title>Get started on ZonaCNC</title>` 
+- Should be: `<title>Empieza con buen pie en ZonaCNC</title>`
+- The email subject and most UI text is Spanish, but the browser tab title is English
+
+**Impact:** Minor but unprofessional; visible when viewing email in browser tab.
+
+---
+
+### F7 [P1] — Free Plan: "1 anuncio activo" vs Previous Reports Showing 3
+**Evidence:** Pricing page `/es/pricing` and subscription page `/es/suscripcion`
+
+Current pricing page shows:
+- Free: **1 anuncio activo**, 5 imágenes/anuncio
+- Starter: **3 anuncios activos**, 10 imágenes/anuncio
+
+Previous QA report (2026-05-06 v2 F12) listed Free = 3 anuncios. This could be:
+1. A deliberate plan change (Free was reduced from 3→1)
+2. A UI regression/bug
+
+Either way, this needs clarification.
+
+**Impact:** If deliberate, needs changelog. If bug, customers see wrong limits.
+
+---
+
+### F8 [P1] — Password Recovery Token Expiry <1h
+**Evidence:** test21 reset token from 10:45 UTC expired by 10:50 UTC (~5 min)
+Message: "La solicitud de cambio de contraseña ha caducado."
+**Previously reported:** Yes (2026-05-06 v2 F9). Still present.
+
+---
+
+## Email Template Language Summary
+
+| Account | # | Type | Subject Lang | Body Lang | Issues |
+|---------|---|------|-------------|-----------|--------|
+| test21 | 8 | Starter welcome | ES ✅ | ES ✅ | Wrong ad count: 1≠3 |
+| test21 | 9 | Onboarding | ES ✅ | ES ✅ | None |
+| test21 | 10 | Invoice paid | ES ✅ | ES ✅ | None |
+| test22 | 11 | Cancellation | ES ✅ | EN ✗ | "Your tu plan plan" |
+| test10 | 14 | Onboarding | ES ✅ | EN ✗ | `{myads_url}` unresolved |
+| test10 | 15 | Invoice paid | ES ✅ | EN ✗ | Full EN body |
+| test26 | 8 | Onboarding | ES ✅ | EN ✗ | `{myads_url}` unresolved |
+| test26 | 10 | Cancellation | ES ✅ | EN ✗ | "Your tu plan plan" |
+| test26 | 15 | Starter welcome | ES ✅ | ES ✅ | Wrong ad count: 1≠3 |
+
+**Pattern:** 4 of 9 billing emails (44%) have wrong language for Spanish accounts. Onboarding and cancellation templates are consistently affected.
+
+---
+
+## Pricing Page Verification
+
+| Plan | Price/mo | Ads | Images | Verified |
+|------|----------|-----|--------|:---:|
+| Free | 0 € | 1 | 5 | ✅ |
+| Starter | 39 € | 3 | 10 | ✅ |
+| Pro | 99 € | 10 | 20 | ✅ |
+| Business | 199 € | 25 | 30 | ✅ |
+| Enterprise | 299 € | 100 | 50 | ✅ |
+
+Annual billing toggle available (save 78 € on Starter).
+
+---
+
+## Account Status (IMAP)
+
+All test7–test30 accounts have working IMAP access (24/24 verified ✅). Unlike previous report where 9 accounts failed auth, all passwords are now functional.
+
+**Critical blocker:** Password recovery emails NOT delivered → cannot log into any test7–test30 account to test actual billing/checkout flow.
+
+---
+
+## Recommendations
+
+1. **P0:** Fix Starter welcome email template → change "Anuncios incluidos: 1" → "3"
+2. **P0:** Fix cancellation email → full Spanish translation, remove "Your tu plan plan" mix
+3. **P0:** Fix onboarding email → render `{myads_url}` variable, use Spanish template
+4. **P0:** Fix password recovery email delivery (SMTP/Mailgun misconfiguration)
+5. **P0:** Fix invoice email language detection → Spanish accounts must get Spanish emails
+6. **P1:** Fix onboarding HTML `<title>` → use Spanish "Empieza con buen pie en ZonaCNC"
+7. **P1:** Clarify Free plan ad count (1 vs 3) — if deliberate change, document; if bug, fix
+8. **P1:** Increase password reset token lifespan from <1h to 24h
+
+---
+
+*Report generated by OpenClaw QA cron job — stripe-billing scenario · 2026-05-06 10:42–11:10 UTC*

--- a/report-stripe-billing-2026-05-06-v2.md
+++ b/report-stripe-billing-2026-05-06-v2.md
@@ -1,0 +1,183 @@
+# QA Report — Stripe Billing · new.zonacnc.com
+**Date:** 2026-05-06 09:40–10:05 UTC  
+**Focus Area:** stripe-billing  
+**Tester:** test3@zonacnc.com (login) + test26/test27/test28 (IMAP email review)  
+**Site:** https://new.zonacnc.com (MODO TEST banner visible)
+
+---
+
+## Scope
+Review pricing plans, checkout flow, Stripe integration, subscription management, facturacion page, and billing email templates. Verify translations and template correctness for test7–test30 pool.
+
+---
+
+## Findings Summary
+
+| # | Severity | Component | Description |
+|---|----------|-----------|-------------|
+| 1 | **P0** | Stripe | Payment session creation fails — Stripe not configured on test server |
+| 2 | **P0** | Email | Password recovery emails not delivered for test27/test28 |
+| 3 | **P0** | Email·Template | Cancellation email: "Hello Test, Your tu plan plan has been canceled" (ES/EN mix) |
+| 4 | **P0** | Email·Template | Starter welcome: "Anuncios incluidos: 1" but pricing shows 3 |
+| 5 | **P1** | Email·Template | "Confirmación decontraseña" subject — missing space |
+| 6 | **P1** | Email·Template | Email `<title>` tags: extra spaces "  Contraseña ", "  Cuenta " |
+| 7 | **P1** | Email·I18N | Cancellation email entirely in English for Spanish account |
+| 8 | **P1** | Email·I18N | English onboarding sent to Spanish account, `{myads_url}` not replaced |
+| 9 | **P1** | Auth | Password recovery tokens expire within ~1h |
+| 10 | **P2** | UI | Breadcrumb shows only "Inicio" on pricing/checkout pages |
+| 11 | **P2** | UI | Back-redirect bug: `/es/?controller=https://...` after saving billing address |
+| 12 | — | Info | Pricing page complete, checkout UI well structured, all 5 plans present |
+| 13 | — | Info | Mi Cuenta sidebar fully functional after vendor registration |
+
+---
+
+## Detailed Findings
+
+### F1 [P0] — Stripe Payment Session Error
+**Page:** `/es/pagar-plan`  
+Clicking "Proceder al pago" shows alert:  
+> **Error al crear la sesión de pago. Inténtalo de nuevo.**
+Stripe checkout session cannot be created — likely missing API key configuration. No redirect to Stripe hosted checkout occurs.
+
+### F2 [P0] — Password Recovery Emails Not Delivered
+- Requested reset for test27@zonacnc.com: form submitted, success alert shown, **no email arrived** (checked at 09:45, 09:50 UTC).
+- Requested reset for test28@zonacnc.com: same result — old inbox unchanged (6 emails, last from May 3).
+- Only test26 had a fresh reset token from earlier this morning (08:35 CEST).
+- **Impact:** Cannot log into test7–test30 pool accounts for billing testing.
+
+### F3 [P0] — Cancellation Email: Broken ES/EN Mix (test26, ID=10)
+```
+Subject: Tu suscripción se ha cancelado
+Title: Subscription Canceled
+Body:  Hello Test,
+       Your tu plan plan has been canceled.
+       If you would like to re-subscribe, you can do so from your account dashboard.
+```
+- "Your tu plan plan" = nonsensical mixing of English "your" + Spanish "tu" + duplicate "plan"
+- Entire body in English despite Spanish customer profile
+- Title "Subscription Canceled" should be "Suscripción cancelada"
+
+### F4 [P0] — Starter Welcome: Wrong Ad Count (test26, ID=15)
+```
+Subject: ¡Bienvenido a Starter! Tu suscripción está activa
+Body:  - Plan: Starter
+       - Anuncios incluidos: 1
+```
+Pricing page states Starter = **3 anuncios activos**. The email says **1**. This misleading information could cause customer confusion.
+
+### F5 [P1] — Missing Space: "Confirmación decontraseña"
+Found in inboxes of **test26** (IDs 9, 12), **test27** (ID=3), **test28** (IDs 3, 5).  
+Subject reads: `[zonacnc.com] Confirmación decontraseña`  
+Should be: `[zonacnc.com] Confirmación de contraseña`  
+**Recurring PrestaShop template bug.** Previously reported.
+
+### F6 [P1] — Email Title Tags: Extra Spaces
+All PrestaShop transactional emails have malformed `<title>` tags:
+- `<title>  Contraseña </title>` (new password email)
+- `<title>  Solicitud de Contraseña </title>` (password reset confirm)
+- `<title>  Cuenta </title>` (welcome email)
+Leading extra spaces → unprofessional browser tab titles.
+
+### F7 [P1] — Cancellation Email in English (test26, ID=10)
+Full email content is English despite test26 having Spanish profile (`Hola QA Tester DE` in other emails). The subject is correctly Spanish, but body is fully English. Language detection logic seems inconsistent.
+
+### F8 [P1] — English Onboarding + Broken Placeholder (test26, ID=8)
+```
+Subject: Empieza con buen pie en ZonaCNC: 3 pasos en 10 minutos
+Title: Get started on ZonaCNC
+Body:  Hello Test,
+       Welcome as a seller on ZonaCNC!
+       Start selling: {myads_url}
+```
+- Title and body in English for Spanish customer
+- `{myads_url}` placeholder NOT replaced (shows literal `{myads_url}`)
+- The newer email (ID=14) correctly uses Spanish template with full links
+
+### F9 [P1] — Password Recovery Token Expiry
+- test26 token from 08:35 CEST → expired by 09:55 CEST (~80 min)  
+Message: "La solicitud de cambio de contraseña ha caducado. Debe solicitar una nueva."
+Tokens should ideally last 24h, not <2h.
+
+### F10 [P2] — Incomplete Breadcrumbs
+On `/es/pricing`, `/es/pagar-plan`, the breadcrumb shows only "Inicio" without the full path. The Mi Cuenta sub-pages (e.g., `/es/suscripcion`, `/es/facturacion`) show correct full paths.
+
+### F11 [P2] — Back-Redirect URL Bug
+After saving billing address with `back` parameter:
+- Expected: redirect to `/es/pagar-plan?plan=starter`  
+- Actual: redirect to `/es/?controller=https://new.zonacnc.com/es/pagar-plan?plan=starter`  
+The full URL is embedded as a query parameter instead of being decoded.
+
+### F12 [INFO] — Pricing Page Complete
+All 5 plans visible:
+| Plan | Price/mo | Ads | Boost | Images | Extras |
+|------|----------|-----|-------|--------|--------|
+| Free | 0 € | 3 | Packs | 5 | Perfil |
+| Starter | 39 € | 3 | Packs | 10 | Perfil |
+| Pro | 99 € | 10 | 3/mo | 20 | Stats, CSV, Priority |
+| Business | 199 € | 25 | 10/mo | 30 | Verified badge, New products |
+| Enterprise | 299 € | 100 | 25/mo | 50 | Verified badge, New products |
+
+Annual billing available (save 78 € on Starter). Monthly/annual toggle present.
+
+### F13 [INFO] — Checkout Page Structure
+- "Resumen del pedido" with plan details
+- Monthly/Annual radio selectors
+- "Proceder al pago" button
+- Payment methods: Visa, Mastercard, AMEX, Apple Pay, Google Pay
+- Stripe compliance badges: PCI-DSS Level 1
+- Trust badges: Sin permanencia, Cancela cuando quieras, SSL/TLS, RGPD, Soporte en castellano
+- Billing explanation text (clear and well translated)
+- All text in correct Spanish
+
+### F14 [INFO] — Subscription Management Page
+After vendor registration, `/es/suscripcion` shows:
+- "Free Gratuito" plan, 0 €
+- Active ads: 0/3
+- "Mejorar plan" link
+- Mi Cuenta sidebar correctly updated: "Panel de Vendedor" replaces "Hazte Vendedor"
+
+### F15 [INFO] — Facturacion Page
+- Accessible at `/es/facturacion`
+- Shows "Sin movimientos todavía" for new vendors
+- "Aquí encontrarás un histórico de los pagos..." intro text well translated
+- Link to subscription management present
+
+---
+
+## Account Status
+
+| Account | IMAP Access | Emails | Notes |
+|---------|------------|--------|-------|
+| test19 | ❌ Auth failed | — | Password changed |
+| test20 | ❌ Auth failed | — | Password changed |
+| test23 | ❌ Auth failed | — | Password changed |
+| test24 | ❌ Auth failed | — | Password changed |
+| test25 | ❌ Auth failed | — | Password changed |
+| test26 | ✅ Active | 15 emails | Rich billing history, both ES/EN templates |
+| test27 | ✅ Active | 4 emails | Only welcome + reset from May 2–3 |
+| test28 | ✅ Active | 6 emails | Old reset tokens, no new delivery |
+| test29 | ❌ Auth failed | — | Password changed |
+| test30 | ❌ Auth failed | — | Password changed |
+
+---
+
+## Test Account Blockers
+Cannot perform full billing test with test7–test30 pool because:
+1. Password recovery emails don't arrive (F2)
+2. Can't log into any test7–test30 account to test subscription purchase
+3. test3 used as workaround for UI review only
+
+---
+
+## Recommendations
+1. **P0: Fix Stripe API configuration** — ensure `STRIPE_SECRET_KEY` is valid in test environment
+2. **P0: Fix email delivery** — investigate why PrestaShop transactional emails (password recovery) don't arrive; SMTP may be misconfigured
+3. **P0: Fix cancellation email template** — complete Spanish translation, remove English content, fix "tu plan plan"
+4. **P0: Fix Starter welcome template** — change "Anuncios incluidos: 1" → "3" to match pricing
+5. **P1: Fix email title tags** — normalize `<title>` spacing in PrestaShop email templates
+6. **P1: Standardize email language detection** — ensure Spanish accounts get Spanish emails consistently
+7. **P1: Fix `{myads_url}` placeholder** — ensure onboarding template variables are replaced
+
+---
+
+*Report generated by OpenClaw QA cron job — stripe-billing scenario*

--- a/responsive-test-results.md
+++ b/responsive-test-results.md
@@ -1,0 +1,141 @@
+# Responsive Testing Report — new.zonacnc.com
+**Date:** 2026-05-06 10:06 UTC  
+**Tester:** QA Bot (test7@zonacnc.com)  
+**Focus Area:** Responsive Design  
+**Viewports Tested:** 390×844 (Mobile), 768×1024 (Tablet), 1440×900 (Desktop)
+
+---
+
+## Executive Summary
+
+| Category | Result | Issues |
+|----------|--------|--------|
+| Responsive Layout | ✅ PASS | Minor polish needed |
+| Console Errors | ❌ FAIL | 4 unique errors on ALL pages |
+| Email Templates | ❌ FAIL | 2 welcome emails in English (should be Spanish) |
+| Authentication | ⚠️ ISSUE | test7 login fails, password recovery works |
+| Cross-browser Consistency | ✅ PASS | Layout consistent across viewports |
+| Test Mode Banner | ✅ PASS | Renders correctly at all sizes |
+
+---
+
+## 1. Responsive Layout Analysis ✅
+
+### Pages Tested
+- Homepage (`/es/`)
+- Login page (`/es/iniciar-sesion`)
+- Registration page (`/es/?controller=registration`)
+- Password recovery (`/es/recuperar-contraseña`)
+- Product listing (`/es/27-otros-tipos-de-maquinaria`)
+- Product detail (`/es/otros-tipos-de-maquinaria/333-transformador-ormazabal.html`)
+
+### Mobile (390×844) Observations
+- **Header:** Simplified — top-bar links hidden ("Contacte con nosotros", "Vendedores", "Tarifas"), language options collapsed into inline text, login shows icon-only
+- **Search:** Hidden behind toggle button ("Mostrar barra de búsqueda")
+- **Footer:** Collapsible accordion sections with "Mostrar/ocultar" toggle buttons
+- **Product cards:** Single column, full-width, images scale properly
+- **Forms:** Full-width inputs, stacked vertically
+- **Breadcrumbs:** Visible and properly condensed
+- **Test mode banner:** Renders correctly at full width
+
+### Tablet (768×1024) Observations
+- **Header:** Top-bar links visible ("Contacte con nosotros", etc.), language as select dropdown, login shows "Iniciar sesión" text
+- **Search:** Full search bar with icon
+- **Footer:** Full columns, no collapsible sections
+- **Category sidebar:** Visible alongside products
+- **Product cards:** Grid layout (likely 2-3 columns)
+
+### Desktop (1440×900) Observations
+- **Header:** Maximum details — all top-bar links, full navigation
+- **Footer:** All columns visible with sub-categories and descriptions
+- **Product listing:** Multi-column grid with category sidebar
+- **Product detail:** Side-by-side layout with image gallery and details
+
+### Responsive Summary
+The responsive design is well-implemented with clean breakpoints. All interactive elements remain accessible at all sizes. No layout overflow or text clipping observed.
+
+---
+
+## 2. Console Errors ❌
+
+**Consistent across ALL pages and ALL viewports:**
+
+| # | Error Message | Severity | Source |
+|---|--------------|----------|--------|
+| 1 | `"Provider's accounts list is empty"` | ERROR | Google One Tap / FedCM |
+| 2 | `"Unexpected token '&'"` | ERROR | HTML inline script (encoding issue) |
+| 3 | `"Not signed in with the identity provider"` | ERROR | Google Identity Services |
+| 4 | `"[GSI_LOGGER]: FedCM get() rejects with NetworkError: Error retrieving a token"` | ERROR | accounts.google.com/gsi/client |
+
+**Analysis:**
+- Errors #1, #3, #4 relate to Google Sign-In (One Tap / FedCM) integration — likely due to the site being in test mode with no real Google OAuth configuration
+- Error #2 `"Unexpected token '&'"` suggests a URL/HTML encoding issue in inline JavaScript — `&` used instead of `&amp;` in a script context
+- These errors fire on page load and persist across all page navigations
+
+**Recommendation:**
+1. Fix the `&` → `&amp;` encoding issue in inline scripts
+2. Configure Google OAuth provider correctly or suppress FedCM errors in test mode
+
+---
+
+## 3. Email Template Review ❌
+
+### Email #41 — "¡Bienvenido a Starter! Tu suscripción está activa"
+- **Subject:** ✅ Spanish — "¡Bienvenido a Starter! Tu suscripción está activa"
+- **TEXT body:** ❌ **ENGLISH** — "Hello Test, Welcome to ZonaCNC! Your Starter plan is now active."
+- **HTML body:** ❌ **ENGLISH** — Full HTML template in English ("Welcome to ZonaCNC", "Plan Details", "Manage Subscription")
+- **Salutation:** ❌ "Hello Test" — placeholder issue, should be "Hola Test Seven"
+
+### Email #42 — "Empieza con buen pie en ZonaCNC: 3 pasos en 10 minutos"
+- **Subject:** ✅ Spanish
+- **TEXT body:** ❌ **ENGLISH** — "Hello Test, Welcome as a seller on ZonaCNC!"
+- **HTML body:** ❌ **ENGLISH** — "Welcome to ZonaCNC", "B2B marketplace for CNC machinery", "Get started on ZonaCNC"
+- **Template variable:** ❌ `{myads_url}` not replaced in TEXT version
+- **Salutation:** ❌ "Hello Test" instead of "Hello Test Seven"
+
+### Email #43 — "Confirmación de contraseña"
+- **Subject:** ✅ Spanish — "Confirmación de contraseña"
+- **TEXT body:** ✅ Spanish — "Hola Test Seven, Confirmación de la solicitud de contraseña en zonacnc.com"
+- **HTML body:** ✅ Spanish — Full PrestaShop email template in Spanish
+- **Salutation:** ✅ "Hola Test Seven"
+
+**Root Cause:** The "zonacncplans" module (Starter welcome + onboarding) uses English-only email templates. The core PrestaShop password reset email has proper Spanish translations.
+
+**Recommendation:** Add Spanish translations for the zonacncplans module email templates.
+
+---
+
+## 4. Authentication Status
+
+- **test7@zonacnc.com login:** ❌ Failed with "Error de autenticación"
+- **Password recovery:** ✅ Email sent and received (email #43 confirmed via IMAP)
+- The account exists (customer ID 6644) but the stored password doesn't match the IMAP password (77G7YmLXuOae)
+
+---
+
+## 5. Pages Tested Summary
+
+| Page | Mobile | Tablet | Desktop | Console Errors | Notes |
+|------|--------|--------|---------|---------------|-------|
+| Homepage `/es/` | ✅ | ✅ | ✅ | 3 | — |
+| Login `/es/iniciar-sesion` | ✅ | ✅ | — | 3 | Error alert renders correctly |
+| Registration | ✅ | ✅ | — | 3 | All fields accessible |
+| Password Recovery | ✅ | — | — | 2 | Success alert renders correctly |
+| Product Listing | ✅ | ✅ | — | 2 | Category sidebar, 362 results |
+| Product Detail | ✅ | — | — | 2 | Gallery, specs table, contact form |
+
+---
+
+## 6. Overall Assessment
+
+**Responsive Design: GOOD ✅**  
+The site handles all tested viewports well. Navigation adapts appropriately, forms remain usable, and content is never cut off or overflowing.
+
+**Email Localization: NEEDS FIX ❌**  
+Two critical email templates (Starter welcome, Onboarding tips) are only available in English while the rest of the platform is in Spanish. This creates an inconsistent user experience.
+
+**Console Errors: NEEDS FIX ❌**  
+Four JavaScript errors fire on every page load. While they don't appear to break functionality, they indicate integration issues (Google OAuth) and an HTML-encoding bug.
+
+**Test Environment Notice: GOOD ✅**  
+The "MODO TEST" banner is clearly visible, properly styled, and renders correctly across all viewports.

--- a/scan_emails.py
+++ b/scan_emails.py
@@ -1,0 +1,105 @@
+import socket, ssl, re, quopri
+
+ctx = ssl.create_default_context()
+
+def get_email_body(user, passwd, eid):
+    s = ctx.wrap_socket(socket.socket(socket.AF_INET), server_hostname='zonacnc.com')
+    s.settimeout(10)
+    s.connect(('zonacnc.com', 993))
+    s.recv(4096)
+    s.send(f'A001 LOGIN {user} {passwd}\r\n'.encode())
+    s.recv(8192)
+    s.send(b'A002 SELECT INBOX\r\n')
+    s.recv(8192)
+    s.send(f'A{eid} FETCH {eid} (BODY[])\r\n'.encode())
+    d = b''
+    while True:
+        c = s.recv(16384)
+        d += c
+        if f'A{eid} OK'.encode() in d: break
+    s.send(b'A999 LOGOUT\r\n')
+    s.recv(4096)
+    s.close()
+    return d
+
+def parse_email(raw):
+    txt = raw.decode('utf-8', errors='replace')
+    result = {}
+    
+    hdr_end = txt.find('\r\n\r\n')
+    headers = txt[:hdr_end] if hdr_end > 0 else txt
+    for line in headers.split('\n'):
+        if line.startswith('Subject: ') and all(x not in line for x in ['Date:', 'From:', 'To:', 'Sender:']):
+            result['subject'] = line[9:].strip()
+            break
+    
+    ctp_idx = txt.find('Content-Type: text/plain')
+    if ctp_idx > 0:
+        after_ct = txt[ctp_idx:]
+        body_start = after_ct.find('\r\n\r\n')
+        if body_start > 0:
+            body_raw = after_ct[body_start+4:]
+            boundary_end = body_raw.find('\r\n--')
+            if boundary_end > 0:
+                body_raw = body_raw[:boundary_end]
+            clean = body_raw.replace('=\r\n', '')
+            try:
+                dec = quopri.decodestring(clean.encode('latin-1')).decode('utf-8', errors='replace')
+            except:
+                dec = clean
+            result['body'] = dec
+    
+    cth_idx = txt.find('Content-Type: text/html')
+    if cth_idx > 0:
+        after_cth = txt[cth_idx:]
+        tm = re.search(r'<title>(.+?)</title>', after_cth)
+        if tm:
+            result['title'] = tm.group(1).strip()
+    
+    return result
+
+def check_issues(body, subj):
+    issues = []
+    if 'myads_url' in body or '{myads_url}' in body:
+        issues.append('UNRESOLVED_PLACEHOLDER_{myads_url}')
+    if 'prorrateado por Stripe' in body:
+        issues.append('UNRESOLVED_PRORATE')
+    if body.startswith('Hello') and 'Hola' not in body:
+        issues.append('ENGLISH_BODY_FOR_ES_ACCT')
+    if 'Your tu plan' in body or 'your tu plan' in body.lower():
+        issues.append('BROKEN_ES_EN_MIX')
+    if 'Anuncios incluidos: 1' in body:
+        issues.append('WRONG_AD_COUNT_1_SHOULD_BE_3')
+    if 'decontraseña' in subj or ('decontraseña' in body and 'Confirmación' in body):
+        issues.append('MISSING_SPACE_decontraseña')
+    return issues
+
+targets = [
+    ('test21@zonacnc.com', 'TDJFJjQNybV7', [(7,'Welcome'), (8,'Starter active'), (9,'Onboarding'), (10,'Invoice paid')]),
+    ('test22@zonacnc.com', 'a2QYlGpy7YbK', [(10,'New password'), (11,'Cancellation')]),
+    ('test16@zonacnc.com', 'l1wFPQQmwRc0', [(12,'Invoice paid'), (13,'Onboarding')]),
+    ('test10@zonacnc.com', '28aP06IHZgvP', [(14,'Onboarding'), (15,'Invoice paid')]),
+    ('test26@zonacnc.com', 'Ttc5ZxPltimz', [(8,'Onboarding EN'), (10,'Cancellation'), (14,'Onboarding ES'), (15,'Starter welcome')]),
+    ('test8@zonacnc.com', 'FCtyMNYkhoCh', [(20,'Onboarding EN'), (22,'Cancellation')]),
+]
+
+for user, pw, emails in targets:
+    for eid, desc in emails:
+        try:
+            raw = get_email_body(user, pw, eid)
+            r = parse_email(raw)
+            body = r.get('body', '')
+            subj = r.get('subject', '')
+            title = r.get('title', '')
+            issues = check_issues(body, subj)
+            if issues:
+                aname = user.split('@')[0]
+                print(f"[{aname} #{eid} {desc}] Subj: {subj[:100]}")
+                if title: print(f"  HTML title: {title}")
+                print(f"  Body: {body[:400]}")
+                print(f"  ISSUES: {issues}")
+                print()
+        except Exception as e:
+            print(f"ERROR {user} #{eid}: {e}")
+
+print("SCAN COMPLETE")


### PR DESCRIPTION
## Summary
Cross-account billing email template audit across test21, test22, test16, test10, test26, test8 accounts.

## P0 Findings
1. **Starter welcome: Wrong ad count** — Email says Anuncios incluidos: 1, pricing page shows 3 (test21, test26)
2. **Cancellation email: English body + Your tu plan plan** — Broken ES/EN language mix (test22, test26)
3. **Onboarding email: English body + unresolved {myads_url}** — Placeholder not rendered (test10, test26)
4. **Password recovery emails NOT delivered** — test18, test22 never received reset emails
5. **Invoice email: English body for Spanish account** — test10 invoice in English

## P1 Findings
6. Onboarding HTML <title> in English
7. Free plan shows 1 anuncio activo (was 3 previously)
8. Password reset tokens expire <1h

Full report: findings-stripe-billing.md
Re: CRON_QA f88c723f