### PR TITLE
QA(responsive): 2 mobile issues (ps-mainmenu overflow + 12 small tap targets) [2026-05-08T1931]

### DIFF
--- a/qa-agent/findings/RESPONSIVE-2026-05-08-1931.md
+++ b/qa-agent/findings/RESPONSIVE-2026-05-08-1931.md
@@ -1,0 +1,102 @@
+# QA Responsive — new.zonacnc.com — 2026-05-08 (19:31 UTC)
+
+**Fecha:** 2026-05-08 19:31 UTC
+**Trigger:** cron tester-responsive (CRON_QA focus_area=responsive)
+**URL:** https://new.zonacnc.com
+**Método:** Playwright Chromium local (chromium-1208) con screenshots full-page en 3 viewports
+
+---
+
+## Resumen: ❌ NO PASA — 2 issues en mobile
+
+| Viewport | Resolución | Resultado | Issues |
+|----------|-----------|-----------|--------|
+| Mobile | 390×844 | ❌ Falló | 2 issues detectados |
+| Tablet | 768×1024 | ✅ Pasó | 0 issues |
+| Desktop | 1440×900 | ✅ Pasó | 0 issues |
+
+---
+
+## Issues detectados (automated)
+
+### #1 🔴 ps-mainmenu fixed overflow en mobile (390px)
+- **Elemento:** `DIV.ps-mainmenu`
+- **Posición:** `position: fixed`
+- **Problema:** El elemento desborda el viewport en mobile 390px. El `scrollWidth > clientWidth + 5` indica que el menú fijo es más ancho que la pantalla.
+- **Impacto:** Provoca scroll horizontal no deseado en mobile, rompe la experiencia responsive.
+- **Severidad:** 🟡 Medium
+
+### #2 🟡 12 tap targets < 40px en mobile
+- **Problema:** 12 elementos interactivos (`button, a, [role="button"], input[type="submit"]`) tienen dimensiones menores a 40px en viewport mobile.
+- **WCAG:** 2.5.5 Target Size (Enhanced) recomienda ≥44px. 40px es un umbral conservador.
+- **Impacto:** Dificulta la interacción táctil precisa en dispositivos móviles.
+- **Severidad:** 🟡 Medium
+
+---
+
+## Issues visuales adicionales (análisis de screenshots)
+
+### #3 🟡 Cookie banner solapa contenido (desktop y tablet)
+- El banner de cookies aparece superpuesto sobre las cards de producto en la parte central de la página.
+- Visible en desktop (1440px) y tablet (768px).
+- **Severidad:** 🟡 Medium — afecta usabilidad, bloquea contenido.
+
+### #4 🟡 Product card overflow en desktop (1440px)
+- La card de producto más a la derecha ("Torno CNC de precisión TEST-7") aparece parcialmente recortada en el borde derecho.
+- Sugiere un contenedor de carrusel/grid sin `overflow` adecuado.
+- **Severidad:** 🟡 Medium
+
+### #5 🔵 Texto truncado en categorías
+- "Accesorios para maquina..." aparece truncado en la sección "Categorías principales".
+- Visible en los 3 viewports.
+- **Severidad:** 🔵 Low — no bloquea funcionalidad pero afecta UX.
+
+### #6 🔵 Test mode banner visible
+- "MODO TEST — entorno de pruebas. Los emails NO llegan a vendedores reales." visible en todas las páginas.
+- Esto es esperado en entorno de pruebas pero debe verificarse que se oculta en producción.
+- **Severidad:** 🔵 Low — informativo.
+
+---
+
+## Páginas verificadas
+
+| URL | Status | Viewport meta | Mobile nav |
+|-----|--------|---------------|------------|
+| `/` | 200 (302→/es/) | ✅ | ✅ |
+| `/es/` | 200 | ✅ | ✅ |
+
+---
+
+## Screenshots
+
+| Viewport | Archivo |
+|----------|---------|
+| Mobile 390×844 | `continuous-testing/playwright-tester/results/responsive-mobile-1778268983401.png` |
+| Tablet 768×1024 | `continuous-testing/playwright-tester/results/responsive-tablet-1778268986813.png` |
+| Desktop 1440×900 | `continuous-testing/playwright-tester/results/responsive-desktop-1778268990108.png` |
+
+---
+
+## Comparativa con ejecución anterior (2026-05-08 14:43–18:27)
+
+| Aspecto | Ejecución anterior | Esta ejecución |
+|---------|-------------------|----------------|
+| Método | Análisis código fuente HTML/CSS | Playwright Chromium local + screenshots |
+| Mobile OK? | ✅ Análisis estático aprobado | ❌ 2 issues detectados con browser real |
+| Tablet OK? | ✅ | ✅ |
+| Desktop OK? | ✅ | ✅ |
+| Cookie banner | No detectado | 🟡 Solapando contenido |
+| ps-mainmenu | No detectado | 🔴 Fixed overflow en 390px |
+
+---
+
+## Conclusión
+
+**new.zonacnc.com tiene 2 issues responsive confirmados en mobile (390px):** el menú fijo `ps-mainmenu` desborda el viewport y hay 12 tap targets por debajo del umbral mínimo de 40px. Tablet y desktop pasan las pruebas automatizadas pero muestran problemas visuales menores (cookie banner solapando, card recortada).
+
+### Recomendaciones
+
+1. **Revisar `ps-mainmenu` CSS** — asegurar `max-width: 100vw` o `width: 100%` en el elemento fixed para mobile.
+2. **Aumentar tap targets** — revisar iconos del header (search, user, cart) y dots del carrusel para que alcancen ≥44px en mobile.
+3. **Cookie banner** — revisar z-index/posicionamiento para que no solape contenido.
+4. **Product grid overflow** — añadir `overflow: hidden` al contenedor del carrusel de productos.


### PR DESCRIPTION
## QA Responsive - new.zonacnc.com - 2026-05-08T19:31 UTC

### Issues encontrados
1. 🔴 ps-mainmenu fixed DIV overflows viewport at 390px mobile
2. 🟡 12 tap targets < 40px on mobile (WCAG 2.5.5)
3. 🟡 Cookie banner overlaps product cards on desktop/tablet
4. 🟡 Product card clipped at right edge on 1440px desktop
5. 🔵 Category text truncation (Accesorios para maquina...)

### Viewports
- Mobile 390×844: ❌ (2 issues)
- Tablet 768×1024: ✅
- Desktop 1440×900: ✅

Screenshots capturados con Playwright Chromium local.

Auto-merge: QA cron responsive.