### PR TITLE
QA responsive 2026-05-09 CRON: 18 issues — 0 srcset site-wide

### DIFF
--- a/continuous-testing/results/responsive-v2-2026-05-09/report.json
+++ b/continuous-testing/results/responsive-v2-2026-05-09/report.json
@@ -1,0 +1,577 @@
+{
+  "ok": false,
+  "passed": "❌ FAILED — 18 issues",
+  "timestamp": "2026-05-09T02:25:51.270Z",
+  "url": "https://new.zonacnc.com",
+  "mode": "responsive (headless audit v2)",
+  "pagesTested": 9,
+  "viewports": [
+    "mobile",
+    "tablet",
+    "desktop"
+  ],
+  "cssAnalysis": {
+    "totalCssChecked": 7,
+    "totalMediaQueries": 54,
+    "cssWithMq": 4,
+    "cssWithoutMq": 3,
+    "breakpoints": [
+      400,
+      480,
+      575,
+      600,
+      640,
+      767,
+      768,
+      991,
+      992,
+      1023,
+      1024,
+      1200
+    ]
+  },
+  "checks": [
+    {
+      "check": "homepage_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 249875B"
+    },
+    {
+      "check": "homepage_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage_mobile_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "homepage_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 249875B"
+    },
+    {
+      "check": "homepage_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage_tablet_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "homepage_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 249875B"
+    },
+    {
+      "check": "homepage_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage_desktop_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "pricing_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 243870B"
+    },
+    {
+      "check": "pricing_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing_mobile_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "pricing_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 243869B"
+    },
+    {
+      "check": "pricing_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing_tablet_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "pricing_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 243870B"
+    },
+    {
+      "check": "pricing_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing_desktop_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-tornos_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 648000B"
+    },
+    {
+      "check": "category-tornos_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-tornos_mobile_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-tornos_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 647898B"
+    },
+    {
+      "check": "category-tornos_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-tornos_tablet_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-tornos_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 647900B"
+    },
+    {
+      "check": "category-tornos_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-tornos_desktop_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-fresadoras_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 618508B"
+    },
+    {
+      "check": "category-fresadoras_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-fresadoras_mobile_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-fresadoras_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 618497B"
+    },
+    {
+      "check": "category-fresadoras_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-fresadoras_tablet_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "category-fresadoras_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 618537B"
+    },
+    {
+      "check": "category-fresadoras_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "category-fresadoras_desktop_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "product_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 289142B"
+    },
+    {
+      "check": "product_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "product_mobile_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "product_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 289492B"
+    },
+    {
+      "check": "product_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "product_tablet_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "product_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 288963B"
+    },
+    {
+      "check": "product_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "product_desktop_lang",
+      "ok": true,
+      "detail": "es-ES"
+    },
+    {
+      "check": "homepage-en_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 245710B"
+    },
+    {
+      "check": "homepage-en_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-en_mobile_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "homepage-en_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 245710B"
+    },
+    {
+      "check": "homepage-en_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-en_tablet_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "homepage-en_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 245710B"
+    },
+    {
+      "check": "homepage-en_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-en_desktop_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "pricing-en_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 240105B"
+    },
+    {
+      "check": "pricing-en_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing-en_mobile_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "pricing-en_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 240105B"
+    },
+    {
+      "check": "pricing-en_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing-en_tablet_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "pricing-en_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 240105B"
+    },
+    {
+      "check": "pricing-en_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "pricing-en_desktop_lang",
+      "ok": true,
+      "detail": "en-US"
+    },
+    {
+      "check": "homepage-fr_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 249847B"
+    },
+    {
+      "check": "homepage-fr_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-fr_mobile_lang",
+      "ok": true,
+      "detail": "fr-FR"
+    },
+    {
+      "check": "homepage-fr_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 249847B"
+    },
+    {
+      "check": "homepage-fr_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-fr_tablet_lang",
+      "ok": true,
+      "detail": "fr-FR"
+    },
+    {
+      "check": "homepage-fr_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 249847B"
+    },
+    {
+      "check": "homepage-fr_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-fr_desktop_lang",
+      "ok": true,
+      "detail": "fr-FR"
+    },
+    {
+      "check": "homepage-de_mobile_status",
+      "ok": true,
+      "detail": "HTTP 200, 248142B"
+    },
+    {
+      "check": "homepage-de_mobile_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-de_mobile_lang",
+      "ok": true,
+      "detail": "de-DE"
+    },
+    {
+      "check": "homepage-de_tablet_status",
+      "ok": true,
+      "detail": "HTTP 200, 248142B"
+    },
+    {
+      "check": "homepage-de_tablet_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-de_tablet_lang",
+      "ok": true,
+      "detail": "de-DE"
+    },
+    {
+      "check": "homepage-de_desktop_status",
+      "ok": true,
+      "detail": "HTTP 200, 248142B"
+    },
+    {
+      "check": "homepage-de_desktop_viewport",
+      "ok": true,
+      "detail": "width=device-width, initial-scale=1"
+    },
+    {
+      "check": "homepage-de_desktop_lang",
+      "ok": true,
+      "detail": "de-DE"
+    },
+    {
+      "check": "global_css_media_queries",
+      "ok": true,
+      "detail": "54 MQs in 4/7 CSS files. Breakpoints: [768, 480, 1024, 600, 991, 575, 1023, 640, 400, 767, 992, 1200]px"
+    }
+  ],
+  "issues": [
+    "[P3][/es/@mobile] ⚠️ 9 images without srcset",
+    "[P3][/es/@tablet] ⚠️ 9 images without srcset",
+    "[P3][/es/@desktop] ⚠️ 9 images without srcset",
+    "[P3][/es/15-tornos@mobile] ⚠️ 42 images without srcset",
+    "[P3][/es/15-tornos@tablet] ⚠️ 42 images without srcset",
+    "[P3][/es/15-tornos@desktop] ⚠️ 42 images without srcset",
+    "[P3][/es/16-fresadoras@mobile] ⚠️ 41 images without srcset",
+    "[P3][/es/16-fresadoras@tablet] ⚠️ 41 images without srcset",
+    "[P3][/es/16-fresadoras@desktop] ⚠️ 41 images without srcset",
+    "[P3][/en/@mobile] ⚠️ 9 images without srcset",
+    "[P3][/en/@tablet] ⚠️ 9 images without srcset",
+    "[P3][/en/@desktop] ⚠️ 9 images without srcset",
+    "[P3][/fr/@mobile] ⚠️ 9 images without srcset",
+    "[P3][/fr/@tablet] ⚠️ 9 images without srcset",
+    "[P3][/fr/@desktop] ⚠️ 9 images without srcset",
+    "[P3][/de/@mobile] ⚠️ 9 images without srcset",
+    "[P3][/de/@tablet] ⚠️ 9 images without srcset",
+    "[P3][/de/@desktop] ⚠️ 9 images without srcset"
+  ],
+  "issueCount": 18,
+  "resultsDir": "/home/node/.openclaw/workspace-tester/continuous-testing/results/responsive-v2-2026-05-09",
+  "pageResults": [
+    {
+      "page": {
+        "path": "/es/",
+        "lang": "ES",
+        "name": "homepage"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/es/pricing",
+        "lang": "ES",
+        "name": "pricing"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/es/15-tornos",
+        "lang": "ES",
+        "name": "category-tornos"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/es/16-fresadoras",
+        "lang": "ES",
+        "name": "category-fresadoras"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/es/maquinaria-metal/13230-torno-cnc-de-precision-test-7-modelo-industrial.html",
+        "lang": "ES",
+        "name": "product"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/en/",
+        "lang": "EN",
+        "name": "homepage-en"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/en/pricing",
+        "lang": "EN",
+        "name": "pricing-en"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/fr/",
+        "lang": "FR",
+        "name": "homepage-fr"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    },
+    {
+      "page": {
+        "path": "/de/",
+        "lang": "DE",
+        "name": "homepage-de"
+      },
+      "viewportStatus": {
+        "mobile": 200,
+        "tablet": 200,
+        "desktop": 200
+      }
+    }
+  ]
+}

--- a/qa-agent/findings/RESPONSIVE-2026-05-09.md
+++ b/qa-agent/findings/RESPONSIVE-2026-05-09.md
@@ -1,19 +1,21 @@
-# QA Responsive — 2026-05-09 00:15 UTC
+# QA Responsive — 2026-05-09 02:19 UTC (CRON run)
 
 **Sitio**: https://new.zonacnc.com
-**Modo**: Headless HTTP audit (MCP remoto DOWN, browser local sin libs sistema)
+**Modo**: Headless HTTP audit v2 (MCP remoto DOWN, browser local sin libs sistema)
 **Viewports testeados**: Mobile (390×844 UA iPhone), Tablet (768×1024 UA iPad), Desktop (1440×900 UA Chrome)
-**Páginas testeadas**: 
-- /es/ homepage ✅
-- /es/pricing ✅
-- /en/ homepage ✅
-- /en/pricing ✅
-- /fr/ homepage ✅
-- /de/ homepage ✅
+**Páginas testeadas (9 total)**: 
+- /es/ homepage ✅ (HTTP 200, 244KB)
+- /es/pricing ✅ (HTTP 200, 238KB)
+- /es/15-tornos ✅ (HTTP 200, 633KB)
+- /es/16-fresadoras ✅ (HTTP 200, 604KB)
+- /es/maquinaria-metal/...html (producto) ✅ (HTTP 200, 282KB)
+- /en/ homepage ✅ (HTTP 200, 240KB)
+- /en/pricing ✅ (HTTP 200, 234KB)
+- /fr/ homepage ✅ (HTTP 200, 244KB)
+- /de/ homepage ✅ (HTTP 200, 242KB)
 
-**MCP remoto pwmcp-zonacnc**: ❌ DOWN (ECONNREFUSED en 51.254.244.216:3000, 3er día consecutivo)
-**Browser local Chromium**: ❌ No disponible (missing libnspr4.so, libnss3.so, etc. — sandbox sin permisos apt)
-**Browser local Firefox**: ❌ Versión 1509 instalada, Playwright requiere 1511 — npx playwright install no completa por missing system deps
+**MCP remoto pwmcp-zonacnc**: ❌ DOWN (ECONNREFUSED en 51.254.244.216:3000, 5º día consecutivo)
+**Browser local**: ❌ No disponible (sandbox sin libs sistema)
 
 ---
 
@@ -21,15 +23,16 @@
 
 | ID | Severidad | Páginas | Descripción |
 |----|-----------|---------|-------------|
-| RESP-001 | Low | Todas las homepages | 9 imágenes sin `srcset` — no se sirven tamaños adaptativos |
-| RESP-002 | Info | N/A | MCP remoto DOWN (3er día) — bloquea tests browser real (menús, overlays, overflow real) |
-| RESP-003 | Info | N/A | Sandbox sin browsers funcionales — sin fallback local para Playwright |
+| RESP-001 | P3 | Homepages (×4 idiomas) | 9 imágenes sin `srcset` — no se sirven tamaños adaptativos |
+| RESP-004 | P3 | Categorías (/es/15-tornos, /es/16-fresadoras) | 41-42 imágenes de producto sin `srcset` |
+| RESP-005 | P3 | Producto individual | 6 imágenes sin `srcset` |
+| RESP-002 | P1 | N/A | MCP remoto DOWN (5º día) — bloquea tests browser real (menús, overlays, overflow real, screenshots) |
 
 ---
 
 ## Detalle
 
-### RESP-001 — Imágenes sin srcset [Low, Recurrente]
+### RESP-001 — Imágenes sin srcset en homepages [P3, Recurrente]
 
 **Impacto**: 9 imágenes en cada homepage (/es/, /en/, /fr/, /de/) se sirven sin atributo `srcset`. Dispositivos móviles descargan la imagen a resolución desktop, desperdiciando ancho de banda (~30-70% más datos).
 
@@ -38,12 +41,28 @@
 - `/en/`: 0/9 imágenes con srcset  
 - `/fr/`: 0/9 imágenes con srcset
 - `/de/`: 0/9 imágenes con srcset
+- 3 viewports × 4 homepages = **12 occurrences** en el report
 
-**Root cause probable**: Las imágenes de producto/listado en el tema Hummingbird no generan variantes responsive. PrestaShop soporta `srcset` nativo desde PS 1.7, requiere configuración de formatos de imagen en BO → Design → Image Settings.
+**Root cause probable**: Las imágenes de producto/listado en el tema Hummingbird no generan variantes responsive. PrestaShop soporta `srcset` nativo desde PS 1.7, requiere configuración de formatos de imagen en BO → Design → Image Settings. No hay elementos `<picture>` en ninguna página.
 
 **Fix sugerido**: Configurar tamaños responsive en BO y/o modificar templates para incluir `{url}` con los tamaños adecuados vía `ImageManager::getSrcSet()`.
 
-**Historial**: Reportado en QA anteriores como RESP-001 recurrente.
+### RESP-004 — Imágenes sin srcset en páginas de categoría [P3, Nuevo]
+
+**Impacto**: 41-42 imágenes de producto por página de categoría sin `srcset`. Impacto significativo en móvil: ~600KB de página con imágenes sin optimizar.
+
+**Evidencia**:
+- `/es/15-tornos`: 0/42 imágenes con srcset (647KB de página)
+- `/es/16-fresadoras`: 0/41 imágenes con srcset (618KB de página)
+- 3 viewports × 2 categorías = **6 occurrences**
+
+**Root cause**: Misma que RESP-001 — el listado de productos en categorías no usa `srcset`.
+
+### RESP-005 — Imágenes sin srcset en página de producto [P3, Nuevo]
+
+**Evidencia**: `/es/maquinaria-metal/...html`: 0/6 imágenes con srcset (288KB de página)
+
+**Total consolidado**: **0 imágenes con srcset en todo el sitio**. 6 imágenes con `loading="lazy"` (positivo), pero sin variantes responsive.
 
 ### RESP-002 — MCP remoto DOWN [Info, Blocker parcial]
 
@@ -87,16 +106,21 @@ Sandbox no tiene Chromium funcional (faltan libs sistema: libnspr4, libnss3, etc
 
 ---
 
-## Páginas — Estado HTTP
+## Páginas — Estado HTTP (9 páginas × 3 viewports)
 
 | Página | Mobile | Tablet | Desktop |
 |--------|--------|--------|---------|
 | /es/ | 200 (244KB) | 200 (244KB) | 200 (244KB) |
-| /es/pricing | 200 (239KB) | 200 (239KB) | 200 (239KB) |
-| /en/ | 200 (244KB) | 200 (244KB) | 200 (244KB) |
+| /es/pricing | 200 (238KB) | 200 (238KB) | 200 (238KB) |
+| /es/15-tornos | 200 (633KB) | 200 (633KB) | 200 (633KB) |
+| /es/16-fresadoras | 200 (604KB) | 200 (604KB) | 200 (604KB) |
+| /es/...producto | 200 (282KB) | 200 (283KB) | 200 (282KB) |
+| /en/ | 200 (240KB) | 200 (240KB) | 200 (240KB) |
 | /en/pricing | 200 (234KB) | 200 (234KB) | 200 (234KB) |
 | /fr/ | 200 (244KB) | 200 (244KB) | 200 (244KB) |
 | /de/ | 200 (242KB) | 200 (242KB) | 200 (242KB) |
+
+✅ **27/27 HTTP checks OK** — todas las páginas sirven correctamente en todos los viewports.
 
 ---
 
@@ -109,11 +133,24 @@ Sandbox no tiene Chromium funcional (faltan libs sistema: libnspr4, libnss3, etc
 
 ---
 
+## Áreas verificadas OK ✅
+
+- **HTML lang** correcto en todas las páginas: es-ES, en-US, fr-FR, de-DE
+- **Viewport meta** `width=device-width, initial-scale=1` en todas las páginas
+- **Menú móvil** hamburger/offcanvas detectado en todas las páginas
+- **CSS Media Queries**: 54 MQs en 4/7 archivos, breakpoints [400, 480, 575, 600, 640, 767, 768, 991, 992, 1023, 1024, 1200]px
+- **Bootstrap responsive grid** activo (col-sm-*, col-md-*, col-lg-*, col-xl-*)
+- **Utilidades display responsive** (d-none/d-block/d-flex condicionales)
+- **Sin overflow risk** detectado en elementos con width fijo >390px
+- **JSON-LD**: 3 bloques en cada homepage
+- **Lazy loading**: `loading="lazy"` en 6 imágenes de homepage
+- **Breakpoints esenciales**: 768px y 1024px presentes ✅
+
 ## Recomendaciones
 
-1. **RESP-001**: Implementar `srcset` en imágenes de producto/listado — configurar formatos de imagen responsive en BO PS
-2. **URGENTE**: Restaurar MCP pwmcp-zonacnc para desbloquear testeo browser real
-3. **Sandbox**: Instalar dependencias de sistema (libnspr4, libnss3, etc.) para habilitar Chromium como fallback
+1. **RESP-001/004/005**: Implementar `srcset` en imágenes de producto/listado/categoría — configurar formatos de imagen responsive en BO PS
+2. **URGENTE (5º día)**: Restaurar MCP pwmcp-zonacnc para desbloquear testeo browser real (screenshots, touch targets, overflow real, sticky interactions)
+3. **Sandbox**: Instalar dependencias de sistema (libnspr4, libnss3, etc.) para habilitar Chromium como fallback local
 4. **Próximo QA responsive con browser**: Re-testear F1 (sticky topbar bloquea hamburger), F2 (hero overflow), y verificar touch targets
 
 ---


### PR DESCRIPTION
## QA Responsive CRON 2026-05-09 02:19 UTC

18 issues encontrados (todos P3): imagenes sin srcset en todo el sitio.

### Hallazgos
- RESP-001 [P3]: 9 imagenes sin srcset en homepages (x4 idiomas, x3 viewports)
- RESP-004 [P3]: 41-42 imagenes sin srcset en paginas de categoria
- RESP-005 [P3]: 6 imagenes sin srcset en pagina de producto

### Verificaciones OK
- HTTP 200 en 27/27 combinaciones (9 paginas x 3 viewports)
- Viewport meta presente en todas las paginas
- HTML lang correcto (es-ES, en-US, fr-FR, de-DE)
- 54 CSS media queries, breakpoints 768/1024 presentes
- Bootstrap responsive grid + utilidades display
- Sin overflow risk detectado
- Lazy loading activo

### Bloqueos
- MCP remoto DOWN (5o dia consecutivo)
- Sin fallback browser local en sandbox

Report: qa-agent/findings/RESPONSIVE-2026-05-09.md