### PR TITLE
QA responsive: Stores all-404, Prices Drop ES regression, Sitemap no responsive infra (6 findings, 1 regression)

### DIFF
--- a/qa-agent/findings/RESPONSIVE-STORES-2026-05-10.md
+++ b/qa-agent/findings/RESPONSIVE-STORES-2026-05-10.md
@@ -1,0 +1,120 @@
+# QA Responsive — Stores + Prices Drop + Sitemap — 2026-05-10 17:57 UTC
+
+**Sitio**: https://new.zonacnc.com
+**Cron ID**: `53983183-66c6-4b72-9b21-404aac116c60`
+**Metodología**: curl + UA simulation (iPhone Safari iOS 17, Chrome 145 Windows)
+**MCP**: DOWN (ECONNREFUSED)
+**Páginas testeadas**: 17 (Stores, Prices Drop, Sitemap, Supplier, Homepages ×4 idiomas)
+**Resultado**: ❌ FAIL — 10/17 páginas devuelven 404 (59% rotas)
+
+---
+
+## Resumen
+
+| ID | Severidad | Páginas | Descripción |
+|----|-----------|---------|-------------|
+| F1 | P2 | Stores (×4) | Todas las páginas de Tiendas 404: ES/EN/FR/DE |
+| F2 | P2 | Prices Drop (×3) | REGRESSION: `/es/bajamos-precios` era 200→ahora 404. FR/DE también 404. |
+| F3 | P3 | Prices Drop EN | `/en/prices-drop` muestra title/H1 "New products" en vez de "Prices drop" |
+| F4 | P2 | Sitemap FR | `/fr/plan-de-site` → 404. ES/EN/DE 200 OK |
+| F5 | P3 | Sitemap ES/EN/DE | Sin infraestructura responsive: no viewport, no BS grid, no menú mobile |
+| F6 | P3 | Supplier ES | `/es/fabricante/1-zonacnc` → 404 |
+
+---
+
+## Detalle
+
+### F1 — Stores pages 404 en los 4 idiomas [P2] 🆕
+
+**URLs afectadas**: `/es/tiendas`, `/en/stores`, `/fr/magasins`, `/de/geschaefte`
+**HTTP**: Todas 404
+**Alternativas probadas**: `/es/stores`, `/en/tiendas`, `/en/store`, `/es/nuestras-tiendas` → todas 404
+**Impacto**: Funcionalidad core de PS (localizador de tiendas) completamente bloqueada. Las páginas 404 tienen infraestructura responsive completa (18 offcanvas, 7 hamburger, 12 hreflang, 303 ARIA en ES).
+**Posible causa**: Módulo/feature de Stores no habilitado en BO o friendly URLs no configuradas.
+
+### F2 — Prices Drop ES regression + FR/DE 404 [P2] ⚠️ REGRESSION
+
+**URLs**:
+- `/es/bajamos-precios` → **404** (era 200 OK el 2026-05-09 03:21 UTC — REGRESSION)
+- `/en/prices-drop` → 200 OK ✅
+- `/fr/prix-en-baisse` → **404**
+- `/de/preisnachlass` → **404**
+
+**Alternativas probadas**: `/es/prices-drop`, `/es/ofertas`, `/fr/prices-drop`, `/de/prices-drop` → todas 404
+**Impacto**: Usuarios de ES/FR/DE no pueden ver productos con descuento. Solo EN funcional.
+**Posible causa**: Reconfiguración de friendly URLs del controlador prices-drop.
+
+### F3 — Prices Drop EN muestra título incorrecto [P3] 🆕
+
+**URL**: `/en/prices-drop` (única que devuelve 200)
+**Title**: `<title>New products</title>` (debería ser "Prices drop")
+**H1**: `<h1>New products</h1>` (debería ser "Prices drop")
+**Impacto**: SEO y UX incorrectos. Los usuarios en EN ven etiquetas de "New products" en una URL de precios rebajados.
+**Posible causa**: Strings de new-products reutilizados como fallback en el controlador de prices-drop.
+
+### F4 — Sitemap FR 404 [P2] 🆕
+
+**URL**: `/fr/plan-de-site` → 404
+**ES/EN/DE**: 200 OK (`/es/mapa-del-sitio`, `/en/sitemap`, `/de/sitemap`)
+**Posible causa**: Falta entrada de friendly URL para sitemap en francés.
+
+### F5 — Sitemap ES/EN/DE sin infraestructura responsive [P3] 🆕
+
+**URLs 200 OK**: `/es/mapa-del-sitio`, `/en/sitemap`, `/de/sitemap`
+**Problemas**:
+- ❌ Sin meta viewport (`name="viewport"`)
+- ❌ Sin Bootstrap grid columns
+- ❌ Sin offcanvas/hamburger menu
+- ❌ Sin hreflang alternate links
+- Tamaños: 1.25MB (ES), 1.25MB (EN), 1.27MB (DE)
+- ARIA inconsistente: ES=292, EN=1, DE=0
+**Impacto**: Páginas no navegables en mobile, sin header/footer del theme.
+**Posible causa**: Controlador de sitemap no extiende el layout del theme principal.
+
+### F6 — Supplier detail page 404 [P3] 🆕
+
+**URL**: `/es/fabricante/1-zonacnc` → 404
+**Alternativa**: `/es/brand/1-zonacnc` → 404
+**Nota**: La página de listado de fabricantes (`/es/fabricantes`) sí devuelve 200 OK (confirmado en test previo).
+**Posible causa**: Fabricante ID=1 sin productos activos o friendly URL mal configurada.
+
+---
+
+## Infraestructura CSS responsive
+
+- **286 media queries** en 6 archivos CSS
+- `theme-74ef8b52.css`: 266 MQ (principal)
+- `listings.css`: 14 MQ
+- `mobile-nav.css`: 3 MQ
+- `consent.css`, `widget.css`, `savedsearch.css`: 1 MQ c/u
+- **Infraestructura sólida** — los problemas son de contenido/URL, no de CSS
+
+## Páginas OK ✅
+
+- Homepages ES/EN/FR/DE: 200 OK, viewport meta, 7 BS cols, 18 offcanvas, 7 hamburger, 12 hreflang, 208-310 ARIA
+- Mobile = Desktop body: IDÉNTICO en todas las páginas (SSR consistente)
+- Páginas 404: Infraestructura responsive completa
+
+---
+
+## Comparación con tests anteriores
+
+| Test | Fecha | Resultado |
+|------|-------|-----------|
+| Pricedrops ES | 2026-05-09 03:21 | ✅ 200 OK |
+| Pricedrops ES | 2026-05-10 17:57 | ❌ 404 (REGRESSION) |
+| Stores (todas) | Nunca testeado | ❌ 404 (nuevo) |
+| Sitemap responsive | Nunca testeado | ❌ Sin infra (nuevo) |
+
+---
+
+## Conclusión
+
+**Resultado global**: ❌ FAIL — 6 findings (3 P2, 3 P3), 1 regresión confirmada.
+**Impacto**: Funcionalidades completas bloqueadas (Stores, Prices Drop) + infraestructura responsive ausente en Sitemaps.
+**Recomendación**: 
+1. Habilitar Stores en BO o corregir friendly URLs (P2, bloqueante)
+2. Investigar regresión de Prices Drop ES (era 200, ahora 404)
+3. Corregir strings EN de Prices Drop
+4. Añadir sitemap FR
+5. Extender layout del theme en sitemap controller

--- a/skills/web-tester/responsive-results/responsive-report-stores-2026-05-10-1757.json
+++ b/skills/web-tester/responsive-results/responsive-report-stores-2026-05-10-1757.json
@@ -1,0 +1,104 @@
+{
+  "timestamp": "2026-05-10T17:57:01Z",
+  "cron_id": "53983183-66c6-4b72-9b21-404aac116c60",
+  "mode": "responsive",
+  "url": "https://new.zonacnc.com",
+  "focus_area": "responsive",
+  "scenario": "Stores + Prices Drop + Sitemap + Supplier pages",
+  "methodology": "curl + UA simulation (iPhone Safari iOS 17, Chrome 145 Windows)",
+  "mcp_status": "DOWN (ECONNREFUSED ws://51.254.244.216:3000)",
+  "local_playwright": "DOWN (missing libnspr4.so)",
+  "scenarios": 1,
+  "overall": "FAIL",
+  "total_pages": 17,
+  "pages_200": 7,
+  "pages_404": 10,
+  "new_findings": 6,
+  "known_confirmed": 0,
+  "findings": [
+    {
+      "id": "RESP-STORES-ALL-404",
+      "severity": "P2",
+      "type": "new",
+      "summary": "All 4 Stores pages return 404: /es/tiendas, /en/stores, /fr/magasins, /de/geschaefte",
+      "details": "The 'Our Stores' page is completely inaccessible across all languages. This is a core PrestaShop feature (store locator). 404 pages have full responsive infrastructure (18 offcanvas, 7 hamburger, 12 hreflang, 303 ARIA in ES) but the content layer is broken.",
+      "fix_hint": "Check if Stores module/feature is enabled in BO or if friendly URLs need configuration.",
+      "status": "open"
+    },
+    {
+      "id": "RESP-PRICEDROPS-ESFRDE-404",
+      "severity": "P2",
+      "type": "regression",
+      "summary": "Prices Drop returns 404 in ES, FR, DE. Only /en/prices-drop is 200 OK",
+      "details": "REGESSION: /es/bajamos-precios was 200 OK in 2026-05-09 03:21 test, now returns 404. /fr/prix-en-baisse and /de/preisnachlass also 404. Only English works. This blocks users from seeing discounted products in 3 of 4 languages.",
+      "fix_hint": "Check friendly URL configuration for prices-drop controller in ES/FR/DE.",
+      "status": "open"
+    },
+    {
+      "id": "RESP-PRICEDROPS-EN-TITLE-H1-MISMATCH",
+      "severity": "P3",
+      "type": "new",
+      "summary": "/en/prices-drop shows Title 'New products' and H1 'New products' instead of 'Prices drop'",
+      "details": "The only working Prices Drop page (EN) displays incorrect labels: both <title> and <h1> say 'New products' when they should say 'Prices drop' or equivalent. Likely a template/i18n string issue — the New Products page strings are being reused.",
+      "fix_hint": "Check translations for prices-drop controller — may be using new-products strings as fallback.",
+      "status": "open"
+    },
+    {
+      "id": "RESP-SITEMAP-FR-404",
+      "severity": "P2",
+      "type": "new",
+      "summary": "/fr/plan-de-site returns 404. ES, EN, DE sitemaps are 200 OK",
+      "details": "French sitemap page is inaccessible. ES (/es/mapa-del-sitio), EN (/en/sitemap), and DE (/de/sitemap) return 200 OK.",
+      "fix_hint": "Missing friendly URL entry for sitemap in French.",
+      "status": "open"
+    },
+    {
+      "id": "RESP-SITEMAP-NO-RESPONSIVE-INFRA",
+      "severity": "P3",
+      "type": "new",
+      "summary": "ES, EN, DE sitemap pages (200 OK) lack responsive infrastructure: no viewport meta, no BS grid, no offcanvas/hamburger, no hreflang",
+      "details": "Sitemap pages render as bare HTML without any responsive infrastructure. Missing: viewport meta tag, Bootstrap grid columns, offcanvas mobile menu, hamburger toggle, hreflang alternate links. Page size is 1.25MB (ES) suggesting full-page renders without mobile optimization.",
+      "metrics": {
+        "es_sitemap_size": 1258478,
+        "en_sitemap_size": 1253801,
+        "de_sitemap_size": 1274369,
+        "aria_es": 292,
+        "aria_en": 1,
+        "aria_de": 0
+      },
+      "fix_hint": "Sitemap controller needs to extend the main theme layout to inherit header/footer/responsive infrastructure.",
+      "status": "open"
+    },
+    {
+      "id": "RESP-SUPPLIER-ES-404",
+      "severity": "P3",
+      "type": "new",
+      "summary": "/es/fabricante/1-zonacnc (supplier page) returns 404",
+      "details": "Supplier/manufacturer detail page for zonacnc brand returns 404. This could affect vendor storefront visibility. The manufacturers listing page (/es/fabricantes) was confirmed 200 OK in previous tests.",
+      "fix_hint": "Check if supplier 1 has active products and if the friendly URL is correctly configured.",
+      "status": "open"
+    }
+  ],
+  "passes": [
+    "Homepage ES/EN/FR/DE: 200 OK, viewport meta, BS grid (7 cols), 18 offcanvas, 7 hamburger, 24 flex, 12 hreflang, 208-310 ARIA",
+    "Mobile = Desktop body: IDENTICAL across all pages (server-side rendering consistent)",
+    "CSS media queries: 286 total across 6 CSS files (listings.css:14, mobile-nav.css:3, consent.css:1, widget.css:1, savedsearch.css:1, theme-74ef8b52.css:266)",
+    "404 pages have full responsive infrastructure: viewport meta, BS grid, offcanvas, hamburger, hreflang, ARIA",
+    "/en/prices-drop: 200 OK with responsive infrastructure",
+    "Sitemaps ES/EN/DE: 200 OK (though lacking responsive infra)",
+    "All pages maintain 12 hreflang alternate links (where header present)"
+  ],
+  "metrics": {
+    "homepage_size": {"es": 255516, "en": 251515, "fr": 255611, "de": 254067, "unit": "bytes"},
+    "sitemap_size": {"es": 1258478, "en": 1253801, "de": 1274369, "unit": "bytes"},
+    "404_page_size_avg": 214500,
+    "css_files_with_mq": 6,
+    "total_media_queries": 286,
+    "homepage_offcanvas": 18,
+    "homepage_hamburger": 7,
+    "homepage_aria_es": 310
+  },
+  "comparison_previous": "Pricedrops ES was 200 OK at 2026-05-09 03:21, now 404 (REGRESSION). Stores pages never tested before. Sitemap responsive infra never tested before. Supplier page never tested before.",
+  "areas_remaining": ["Order history (responsive)", "Checkout flow deep (responsive)", "PDP responsive"],
+  "regression_summary": "1 REGRESSION (pricedrops ES 200→404). 5 NEW findings. Stores all-404 is the most impactful — core PS feature completely blocked."
+}


### PR DESCRIPTION
## QA Responsive — Stores + Prices Drop + Sitemap + Supplier

**Cron:** 53983183-66c6-4b72-9b21-404aac116c60
**Focus:** responsive
**Methodology:** curl + UA simulation (MCP DOWN)
**Pages tested:** 17 across 4 languages
**Result:** ❌ FAIL — 10/17 pages 404 (59%)

### Findings (6 total: 3 P2, 3 P3)

| ID | Severity | Description |
|----|----------|-------------|
| F1 | P2 | Stores all-404 (ES/EN/FR/DE) |
| F2 | P2 | Prices Drop 404 in ES/FR/DE — ES REGRESSION (was 200) |
| F3 | P3 | Prices Drop EN title/H1 says New products instead of Prices drop |
| F4 | P2 | Sitemap FR 404 |
| F5 | P3 | Sitemap ES/EN/DE no responsive infra (no viewport, BS, menu) |
| F6 | P3 | Supplier detail 404 |

### Regression
/es/bajamos-precios was 200 OK at 2026-05-09 03:21, now returns 404.

### CSS Infra
286 media queries across 6 CSS files — responsive CSS infrastructure is solid. Problems are content/URL layer.